### PR TITLE
Issue 8 create schema

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,6 @@ services:
     image: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: postgres
     ports:
       - 5432:5432

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/deezone/HydroBytes-BaseStation
 go 1.14
 
 require (
+	github.com/GuiaBolso/darwin v0.0.0-20191218124601-fd6d2aa3d244
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/GuiaBolso/darwin v0.0.0-20191218124601-fd6d2aa3d244 h1:dqzm54OhCqY8RinR/cx+Ppb0y56Ds5I3wwWhx4XybDg=
+github.com/GuiaBolso/darwin v0.0.0-20191218124601-fd6d2aa3d244/go.mod h1:3sqgkckuISJ5rs1EpOp6vCvwOUKe/z9vPmyuIlq8Q/A=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=

--- a/main.go
+++ b/main.go
@@ -27,13 +27,19 @@ import (
  * Note: use of "stuct tags" (ex: `json:"id"`) to manage the names of properties to be lowercase and snake_case. Due to
  * the use of case for visibility in Go "id" rather and "Id" would result in the value being excluded in the JSON
  * response as the encoding/json package is external to this package.
+ *
+ * Note: the use of db:"id" allows renaming to map to the column used in the database
  */
 type StationTypes struct {
-	Id          int       `db:"id"           json:"id"`
+	Id          string    `db:"id"           json:"id"`
 	Name        string    `db:"name"         json:"name"`
 	Description string    `db:"description"  json:"description"`
 	DateCreated time.Time `db:"date_created" json:"date_created"`
 	DateUpdated time.Time `db:"date_updated" json:"date_updated"`
+}
+
+type StationService struct {
+	db *sqlx.DB
 }
 
 // Main entry point for program.
@@ -85,6 +91,9 @@ func main() {
 	// =========================================================================
 	// Start API Service
 
+	// Create copy of service (ss) to allow passing method (ss.List) to map to handler
+	ss := StationService{db: db}
+
 	/**
 	 * Convert the ListStationTypes function to a type that implements http.Handler
 	 * See https://education.ardanlabs.com/courses/take/ultimate-syntax/lessons/13570357-type-conversions for details
@@ -100,7 +109,7 @@ func main() {
 	 */
 	api := http.Server{
 		Addr:         "localhost:8000",
-		Handler:      http.HandlerFunc(ListStationTypes),
+		Handler:      http.HandlerFunc(ss.List),
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,
 	}
@@ -171,11 +180,17 @@ func main() {
  * Note: If you open localhost:8000 in your browser, you may notice double requests being made. This happens because
  * the browser sends a request in the background for a website favicon. More the reason to use Postman to test!
  */
-func ListStationTypes(w http.ResponseWriter, r *http.Request) {
-	list := []StationTypes{
-		{Id: 1, Name: "Base", Description: "Coordinator for all station types - monitor, command and control. Access point to public Intenet."},
-		{Id: 2, Name: "Water", Description: "Management of water resources. Controls water levels in resavour and impliments irrigation."},
-		{Id: 3, Name: "Plant", Description: "Monitors and reports plant health."},
+func (s *StationService) List(w http.ResponseWriter, r *http.Request) {
+
+	list := []StationTypes{}
+	const q = "SELECT id, name, description, date_created, date_updated FROM station_types"
+
+	// https://godoc.org/github.com/jmoiron/sqlx#DB.Select
+	// SELECT destination (list) and query (q)
+	if err := s.db.Select(&list, q); err != nil {
+		log.Println("error quering database", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	// https://golang.org/pkg/encoding/json/#Marshal

--- a/schema/migrate.go
+++ b/schema/migrate.go
@@ -1,0 +1,42 @@
+package schema
+
+import (
+	"github.com/GuiaBolso/darwin"
+	"github.com/jmoiron/sqlx"
+)
+
+// migrations contains the queries needed to construct the database schema.
+// Entries should never be removed from this slice once they have been ran in
+// production.
+//
+// Including the queries directly in this file has the same pros/cons mentioned
+// in seeds.go
+
+var migrations = []darwin.Migration{
+	{
+		Version:	 1,
+		Description: "Add station types",
+		Script: `
+CREATE TABLE station_types (
+	id           UUID,
+	name         TEXT,
+	description  TEXT,
+	date_created TIMESTAMP,
+	date_updated TIMESTAMP,
+
+	PRIMARY KEY (id)
+);`,
+	},
+
+}
+
+// Migrate attempts to bring the schema for db up to date with the migrations
+// defined in this package.
+func Migrate(db *sqlx.DB) error {
+
+	driver := darwin.NewGenericDriver(db.DB, darwin.PostgresDialect{})
+
+	d := darwin.New(driver, migrations, nil)
+
+	return d.Migrate()
+}

--- a/schema/seed.go
+++ b/schema/seed.go
@@ -1,0 +1,44 @@
+package schema
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+// seeds is a string constant containing all of the queries needed to get the
+// db seeded to a useful state for development.
+//
+// Using a constant in a .go file is an easy way to ensure the queries are part
+// of the compiled executable and avoids pathing issues with the working
+// directory. It has the downside that it lacks syntax highlighting and may be
+// harder to read for some cases compared to using .sql files. You may also
+// consider a combined approach using a tool like packr or go-bindata.
+//
+// Note that database servers besides PostgreSQL may not support running
+// multiple queries as part of the same execution so this single large constant
+// may need to be broken up.
+
+const seeds = `
+INSERT INTO station_types (id, name, description, date_created, date_updated) VALUES
+	('a2b0639f-2cc6-44b8-b97b-15d69dbb511e', 'Base', 'Coordinator for all station types - monitor, command and control. Access point to public Intenet.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00'),
+	('72f8b983-3eb4-48db-9ed0-e45cc6bd716b', 'Water', 'Management of water resources. Controls water levels in resavour and impliments irrigation.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00'),
+    ('5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant', 'Monitors and reports plant health.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00')
+	ON CONFLICT DO NOTHING;
+`
+
+// Seed runs the set of seed-data queries against db. The queries are ran in a
+// transaction and rolled back if any fail.
+func Seed(db *sqlx.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(seeds); err != nil {
+		if err := tx.Rollback(); err != nil {
+			return err
+		}
+		return err
+	}
+
+	return tx.Commit()
+}


### PR DESCRIPTION
resolves #8 

### Description

Adds migration and seed logic for `station_types` database tables.

### How to Test

- [ ] run `migration` to create `station_types` table
- [ ] run `seed` to populate `station_types` table with seed data

![image](https://user-images.githubusercontent.com/2119264/103599236-b0214080-4ed2-11eb-8fa8-938fced3a2b6.png)

- [ ] confirm seed data is in `station_types` table

![image](https://user-images.githubusercontent.com/2119264/103599803-fcb94b80-4ed3-11eb-8ec6-65bba01d92f9.png)

