### PR TITLE
Issue-17 Use log as local rather than global method

### DIFF
--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -15,6 +15,7 @@ import (
 
 type StationTypes struct {
 	DB *sqlx.DB
+	Log *log.Logger
 }
 
 /**
@@ -31,7 +32,7 @@ func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) {
 
 	list, err := station_types.List(st.DB)
 	if err != nil {
-		log.Printf("error: listing station types: %s", err)
+		st.Log.Printf("error: listing station types: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -39,7 +40,7 @@ func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) {
 	// https://golang.org/pkg/encoding/json/#Marshal
 	data, err := json.Marshal(list)
 	if err != nil {
-		log.Println("error marshalling result", err)
+		st.Log.Println("error marshalling result", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -49,6 +50,6 @@ func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) {
 
 	// https://golang.org/pkg/net/http/#Request.Write
 	if _, err := w.Write(data); err != nil {
-		log.Println("error writing result", err)
+		st.Log.Println("error writing result", err)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -39,6 +39,13 @@ func run() error {
 	// ex: readTimeout time.Duration   = 5 * time.Second
 
 	// =========================================================================
+	// Logging
+
+	// Use "shadowing" to override the global log package value. See https://golang.org/src/log/log.go#L37 for possible
+	// bit values to manage output
+	log := log.New(os.Stdout, "STATIONS : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+
+	// =========================================================================
 	// Configuration
 
 	var cfg struct {
@@ -100,7 +107,7 @@ func run() error {
 	// Start API Service
 
 	// Create copy of service (ss) to allow passing method (ss.List) to map to handler
-	stationTypeHandler := handlers.StationTypes{DB: db}
+	stationTypeHandler := handlers.StationTypes{DB: db, Log: log}
 
 	/**
 	 * Convert the ListStationTypes function to a type that implements http.Handler


### PR DESCRIPTION
resolves #17  

### Description

This PR refactors the use of `log` to be a "ghosted" variable making the variable/method local rather than global.

### How to Test

- [ ] confirm `cmd/api` functions as expected and exits gracefully when terminated
```
 > go run ./cmd/api
2021/01/09 21:15:20 main : Started
2021/01/09 21:15:20 main : Config :
--web-address=localhost:8000
--web-read-timeout=5s
--web-write-timeout=5s
--web-shutdown-timeout=5s
--db-user=postgres
--db-host=localhost
--db-name=postgres
--db-disable-tls=true
2021/01/09 21:15:20 main : API listening on localhost:8000

^C2021/01/09 21:15:34 main : Start shutdown
2021/01/09 21:15:34 main : Completed
```