### PR TITLE
Issue 23 refactor request response

### DIFF
--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	// Core packages
-	"encoding/json"
 	"log"
 	"net/http"
 	"time"
 
 	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
 	"github.com/deezone/HydroBytes-BaseStation/internal/station_types"
 
 	// Third party packages
@@ -24,32 +24,25 @@ type StationTypes struct {
 // station type with generated fields is sent back in the response.
 func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) {
 
-	var np station_types.NewStationTypes
+	var nst station_types.NewStationTypes
 
-	if err := json.NewDecoder(r.Body).Decode(&np); err != nil {
+	if err := web.Decode(r, &nst); err != nil {
 		st.log.Println("decoding station type", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	station_type, err := station_types.Create(st.db, np, time.Now())
+	station_type, err := station_types.Create(st.db, nst, time.Now())
 	if err != nil {
 		st.log.Println("creating station type", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	data, err := json.Marshal(station_type)
-	if err != nil {
-		st.log.Println("error marshalling result", err)
+	if err := web.Respond(w, &station_type, http.StatusCreated); err != nil {
+		st.log.Println("encoding response", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusCreated)
-	if _, err := w.Write(data); err != nil {
-		st.log.Println("error writing result", err)
 	}
 }
 
@@ -72,20 +65,9 @@ func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// https://golang.org/pkg/encoding/json/#Marshal
-	data, err := json.Marshal(list)
-	if err != nil {
-		st.log.Println("error marshalling result", err)
-		w.WriteHeader(http.StatusInternalServerError)
+	if err := web.Respond(w, list, http.StatusOK); err != nil {
+		st.log.Println("encoding response", "error", err)
 		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-
-	// https://golang.org/pkg/net/http/#Request.Write
-	if _, err := w.Write(data); err != nil {
-		st.log.Println("error writing result", err)
 	}
 }
 
@@ -100,16 +82,9 @@ func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := json.Marshal(station)
-	if err != nil {
-		st.log.Println("error marshalling result", err)
+	if err := web.Respond(w, station, http.StatusOK); err != nil {
+		st.log.Println("encoding response", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(data); err != nil {
-		st.log.Println("error writing result", err)
 	}
 }

--- a/internal/platform/web/request.go
+++ b/internal/platform/web/request.go
@@ -1,0 +1,17 @@
+package web
+
+import (
+	// Code packages
+	"encoding/json"
+	"net/http"
+)
+
+// Decode reads the body of an HTTP request looking for a JSON document. The
+// body is decoded into the provided value.
+func Decode(r *http.Request, val interface{}) error {
+	if err := json.NewDecoder(r.Body).Decode(val); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -1,0 +1,29 @@
+package web
+
+import (
+	// Core packages
+	"encoding/json"
+	"net/http"
+)
+
+// Respond converts a Go value to JSON and sends it to the client.
+func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
+
+	// Convert the response value to JSON.
+	// https://golang.org/pkg/encoding/json/#Marshal
+	res, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	// Respond with the provided JSON.
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
+
+	// https://golang.org/pkg/net/http/#Request.Write
+	if _, err := w.Write(res); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
resolves #23     

### Description

This PR refactors the api internal handlers to move common request/response functionality to `/internal/platform/web`.

### How to Test

- confirm existing endpoints continue to work as expected
  - [ ] `GET /v1/station-types`
  - [ ] `GET /v1/station-types/{id}`
  - [ ] `POST /v1/station-types`
