### PR TITLE
Issue-25 Refactor error response

### DIFF
--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -65,7 +65,14 @@ func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) error {
 
 	station_type, err := station_types.Retrieve(st.db, id)
 	if err != nil {
-		return errors.Wrapf(err, "getting station tyoes %q", id)
+		switch err {
+		case station_types.ErrNotFound:
+			return web.NewRequestError(err, http.StatusNotFound)
+		case station_types.ErrInvalidID:
+			return web.NewRequestError(err, http.StatusBadRequest)
+		default:
+			return errors.Wrapf(err, "getting product %q", id)
+		}
 	}
 
 	return web.Respond(w, station_type, http.StatusOK)

--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"github.com/pkg/errors"
 	// Core packages
 	"log"
 	"net/http"
@@ -22,28 +23,20 @@ type StationTypes struct {
 
 // Create decodes the body of a request to create a new station type. The full
 // station type with generated fields is sent back in the response.
-func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) {
+func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) error {
 
 	var nst station_types.NewStationTypes
 
-	if err := web.Decode(r, &nst); err != nil {
-		st.log.Println("decoding station type", "error", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
+	if err := web.Decode(r, &st); err != nil {
+		return errors.Wrap(err, "decoding new station tyoe")
 	}
 
 	station_type, err := station_types.Create(st.db, nst, time.Now())
 	if err != nil {
-		st.log.Println("creating station type", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+		return errors.Wrap(err, "creating new station tyoe")
 	}
 
-	if err := web.Respond(w, &station_type, http.StatusCreated); err != nil {
-		st.log.Println("encoding response", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	return web.Respond(w, &station_type, http.StatusCreated)
 }
 
 /**
@@ -56,35 +49,24 @@ func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) {
  * Note: If you open localhost:8000 in your browser, you may notice double requests being made. This happens because
  * the browser sends a request in the background for a website favicon. More the reason to use Postman to test!
  */
-func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) {
+func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) error {
 
 	list, err := station_types.List(st.db)
 	if err != nil {
-		st.log.Println("listing station types", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+		return errors.Wrap(err, "getting station tyoe list")
 	}
 
-	if err := web.Respond(w, list, http.StatusOK); err != nil {
-		st.log.Println("encoding response", "error", err)
-		return
-	}
+	return web.Respond(w, list, http.StatusOK)
 }
 
 // Retrieve finds a single station type identified by an ID in the request URL.
-func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) {
+func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	station, err := station_types.Retrieve(st.db, id)
+	station_type, err := station_types.Retrieve(st.db, id)
 	if err != nil {
-		st.log.Println("getting product", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+		return errors.Wrapf(err, "getting station tyoes %q", id)
 	}
 
-	if err := web.Respond(w, station, http.StatusOK); err != nil {
-		st.log.Println("encoding response", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	return web.Respond(w, station_type, http.StatusOK)
 }

--- a/internal/platform/web/errors.go
+++ b/internal/platform/web/errors.go
@@ -1,0 +1,25 @@
+package web
+
+// ErrorResponse is the form used for API responses from failures in the API.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// Error is used to pass an error during the request through the
+// application with web specific context.
+type Error struct {
+	Err    error
+	Status int
+}
+
+// NewRequestError wraps a provided error with an HTTP status code. This
+// function should be used when handlers encounter expected errors.
+func NewRequestError(err error, status int) error {
+	return &Error{err, status}
+}
+
+// Error implements the error interface. It uses the default message of the
+// wrapped error. This is what will be shown in the services' logs.
+func (err *Error) Error() string {
+	return err.Err.Error()
+}

--- a/internal/platform/web/request.go
+++ b/internal/platform/web/request.go
@@ -1,7 +1,7 @@
 package web
 
 import (
-	// Code packages
+	// Core packages
 	"encoding/json"
 	"net/http"
 )
@@ -10,7 +10,7 @@ import (
 // body is decoded into the provided value.
 func Decode(r *http.Request, val interface{}) error {
 	if err := json.NewDecoder(r.Body).Decode(val); err != nil {
-		return err
+		return NewRequestError(err, http.StatusBadRequest)
 	}
 
 	return nil

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -13,12 +13,14 @@ import (
 func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
 
 	// Convert the response value to JSON.
+	// https://golang.org/pkg/encoding/json/#Marshal
 	res, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
 
 	// Respond with the provided JSON.
+	// https://golang.org/pkg/net/http/#Request.Write
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(statusCode)
 	if _, err := w.Write(res); err != nil {

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -4,13 +4,15 @@ import (
 	// Core packages
 	"encoding/json"
 	"net/http"
+
+	// Third party packages
+	"github.com/pkg/errors"
 )
 
 // Respond converts a Go value to JSON and sends it to the client.
 func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
 
 	// Convert the response value to JSON.
-	// https://golang.org/pkg/encoding/json/#Marshal
 	res, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -19,11 +21,34 @@ func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
 	// Respond with the provided JSON.
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(statusCode)
-
-	// https://golang.org/pkg/net/http/#Request.Write
 	if _, err := w.Write(res); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// RespondError sends an error reponse back to the client.
+func RespondError(w http.ResponseWriter, err error) error {
+
+	// If the error was of the type *Error, the handler has
+	// a specific status code and error to return.
+	if webErr, ok := errors.Cause(err).(*Error); ok {
+		er := ErrorResponse{
+			Error: webErr.Err.Error(),
+		}
+		if err := Respond(w, er, webErr.Status); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// If not, the handler sent any arbitrary error value so use 500.
+	er := ErrorResponse{
+		Error: http.StatusText(http.StatusInternalServerError),
+	}
+	if err := Respond(w, er, http.StatusInternalServerError); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -1,16 +1,18 @@
 package web
 
 import (
+	// Code packages
 	"log"
 	"net/http"
 
+	// Third-party packages
 	"github.com/go-chi/chi"
 )
 
 // Handler is the signature used by all application handlers in this service.
 type Handler func(http.ResponseWriter, *http.Request) error
 
-// App is the entrypoint into our application and what controls the context of
+// App is the entry point into our application and what controls the context of
 // each request. Feel free to add any configuration data/logic on this type.
 type App struct {
 	log *log.Logger


### PR DESCRIPTION
resolves #25      

### Description

This PR refactors the error response to include the response code as well as a specific massage. This safegards the error message from displaying sensitive information if it's an internal error.

### How to Test

- [ ] send request to `POST /v1/station-types` with empty body. The response should be `400 Bad Request`:
```
{
    "error": "EOF"
}
```

- [ ] send request to `GET /v1/station-types/{id}` where the `id` is an invalid `uuid` or a `uuid` that does not exist . The response should be an error message that reflects the issue detected.
  - [ ] `GET /v1/station-types/cow-over-the-moon - invalid `UUID, responds with `400 Bad Request`
```
{
    "error": "ID is not in its proper UUID format"
}
``` 

  - [ ] `GET /v1/station-types/a2b0639f-2cc6-44b8-b97b-15d69dbb511f` - `UUID` does not exist, responds with `404 Not Found`
 ```
{
    "error": "station type not found"
}
```