### PR TITLE
Issue-27 Unit Tests for  business logic and Functional Tests for API Endpoints

### DIFF
--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -27,13 +27,13 @@ func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) error {
 
 	var nst station_types.NewStationTypes
 
-	if err := web.Decode(r, &st); err != nil {
+	if err := web.Decode(r, &nst); err != nil {
 		return errors.Wrap(err, "decoding new station tyoe")
 	}
 
 	station_type, err := station_types.Create(st.db, nst, time.Now())
 	if err != nil {
-		return errors.Wrap(err, "creating new station tyoe")
+		return errors.Wrap(err, "creating new station type")
 	}
 
 	return web.Respond(w, &station_type, http.StatusCreated)
@@ -71,7 +71,7 @@ func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) error {
 		case station_types.ErrInvalidID:
 			return web.NewRequestError(err, http.StatusBadRequest)
 		default:
-			return errors.Wrapf(err, "getting product %q", id)
+			return errors.Wrapf(err, "getting station type %q", id)
 		}
 	}
 

--- a/internal/platform/database/databasetest/doc.go
+++ b/internal/platform/database/databasetest/doc.go
@@ -1,0 +1,4 @@
+// Package databasetest provides tools for launching and preparing databases in
+// Docker containers to be used in tests. It has direct dependencies on the
+// testing package to show that it should not be used for production code.
+package databasetest

--- a/internal/platform/database/databasetest/docker.go
+++ b/internal/platform/database/databasetest/docker.go
@@ -1,0 +1,87 @@
+package databasetest
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"testing"
+)
+
+// Container tracks information about a docker container started for tests.
+type Container struct {
+	ID   string
+	Host string // IP:Port
+}
+
+// StartContainer runs a postgres container to execute commands.
+func StartContainer(t *testing.T) *Container {
+	t.Helper()
+
+	cmd := exec.Command("docker", "run", "-P", "-d", "postgres:11.1-alpine")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("could not start container: %v", err)
+	}
+
+	id := out.String()[:12]
+	t.Log("DB ContainerID:", id)
+
+	cmd = exec.Command("docker", "inspect", id)
+	out.Reset()
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("could not inspect container %s: %v", id, err)
+	}
+
+	var doc []struct {
+		NetworkSettings struct {
+			Ports struct {
+				TCP5432 []struct {
+					HostIP   string `json:"HostIp"`
+					HostPort string `json:"HostPort"`
+				} `json:"5432/tcp"`
+			} `json:"Ports"`
+		} `json:"NetworkSettings"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("could not decode json: %v", err)
+	}
+
+	network := doc[0].NetworkSettings.Ports.TCP5432[0]
+
+	c := Container{
+		ID:   id,
+		Host: network.HostIP + ":" + network.HostPort,
+	}
+
+	t.Log("DB Host:", c.Host)
+
+	return &c
+}
+
+// StopContainer stops and removes the specified container.
+func StopContainer(t *testing.T, c *Container) {
+	t.Helper()
+
+	if err := exec.Command("docker", "stop", c.ID).Run(); err != nil {
+		t.Fatalf("could not stop container: %v", err)
+	}
+	t.Log("Stopped:", c.ID)
+
+	if err := exec.Command("docker", "rm", c.ID, "-v").Run(); err != nil {
+		t.Fatalf("could not remove container: %v", err)
+	}
+	t.Log("Removed:", c.ID)
+}
+
+// DumpContainerLogs runs "docker logs" against the container and send it to t.Log
+func DumpContainerLogs(t *testing.T, c *Container) {
+	t.Helper()
+
+	out, err := exec.Command("docker", "logs", c.ID).CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not log container: %v", err)
+	}
+	t.Logf("Logs for %s\n%s:", c.ID, out)
+}

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -20,8 +20,8 @@ import (
 const seeds = `
 INSERT INTO station_types (id, name, description, date_created, date_updated) VALUES
 	('a2b0639f-2cc6-44b8-b97b-15d69dbb511e', 'Base', 'Coordinator for all station types - monitor, command and control. Access point to public Intenet.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00'),
-	('72f8b983-3eb4-48db-9ed0-e45cc6bd716b', 'Water', 'Management of water resources. Controls water levels in resavour and impliments irrigation.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00'),
-    ('5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant', 'Monitors and reports plant health.', '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00')
+	('72f8b983-3eb4-48db-9ed0-e45cc6bd716b', 'Water', 'Management of water resources. Controls water levels in resavour and impliments irrigation.', '2021-01-01 00:00:02.000001+00', '2021-01-01 00:00:02.000001+00'),
+    ('5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant', 'Monitors and reports plant health.', '2021-01-01 00:00:03.000001+00', '2021-01-01 00:00:03.000001+00')
 	ON CONFLICT DO NOTHING;
 `
 

--- a/internal/station_types/station_types.go
+++ b/internal/station_types/station_types.go
@@ -20,7 +20,7 @@ var (
 	ErrInvalidID = errors.New("ID is not in its proper UUID format")
 )
 
-// Create adds a Product to the database. It returns the created Product with
+// Create adds a StationType to the database. It returns the created StationTypes with
 // fields like ID and DateCreated populated..
 func Create(db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, error) {
 	st := StationTypes{
@@ -51,20 +51,20 @@ func Create(db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, err
 	return &st, nil
 }
 
-// List gets all Products from the database.
+// List gets all StationTypes from the database.
 func List(db *sqlx.DB) ([]StationTypes, error) {
-	products := []StationTypes{}
+	station_types := []StationTypes{}
 
 	const q = `
 		SELECT
 			id, name, description, date_created, date_updated
 		FROM station_types`
 
-	if err := db.Select(&products, q); err != nil {
+	if err := db.Select(&station_types, q); err != nil {
 		return nil, errors.Wrap(err, "selecting station types")
 	}
 
-	return products, nil
+	return station_types, nil
 }
 
 // Retrieve gets a specific StationType from the database.

--- a/internal/station_types/station_types_test.go
+++ b/internal/station_types/station_types_test.go
@@ -1,0 +1,57 @@
+package station_types_test
+
+import (
+	// Core packages
+	"testing"
+	"time"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/station_types"
+	"github.com/deezone/HydroBytes-BaseStation/internal/schema"
+	"github.com/deezone/HydroBytes-BaseStation/internal/tests"
+
+	// Third-party packages
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStationTypesCreateRetrieve(t *testing.T) {
+	db, teardown := tests.NewUnit(t)
+	defer teardown()
+
+	newP := station_types.NewStationTypes{
+		Name:        "Base",
+		Description: "Coordinator for all station types - monitor, command and control. Access point to public Intenet.",
+	}
+	now := time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	st0, err := station_types.Create(db, newP, now)
+	if err != nil {
+		t.Fatalf("creating station type st0: %s", err)
+	}
+
+	st1, err := station_types.Retrieve(db, st0.Id)
+	if err != nil {
+		t.Fatalf("getting product p0: %s", err)
+	}
+
+	if diff := cmp.Diff(st1, st0); diff != "" {
+		t.Fatalf("fetched != created:\n%s", diff)
+	}
+}
+
+func TestStationTypesList(t *testing.T) {
+	db, teardown := tests.NewUnit(t)
+	defer teardown()
+
+	if err := schema.Seed(db); err != nil {
+		t.Fatal(err)
+	}
+
+	sts, err := station_types.List(db)
+	if err != nil {
+		t.Fatalf("listing station types: %s", err)
+	}
+	if exp, got := 3, len(sts); exp != got {
+		t.Fatalf("expected station types list size %v, got %v", exp, got)
+	}
+}

--- a/internal/station_types/station_types_test.go
+++ b/internal/station_types/station_types_test.go
@@ -31,7 +31,7 @@ func TestStationTypesCreateRetrieve(t *testing.T) {
 
 	st1, err := station_types.Retrieve(db, st0.Id)
 	if err != nil {
-		t.Fatalf("getting product p0: %s", err)
+		t.Fatalf("getting station type p0: %s", err)
 	}
 
 	if diff := cmp.Diff(st1, st0); diff != "" {

--- a/internal/tests/test.go
+++ b/internal/tests/test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	// Core packages
+	"testing"
+	"time"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database"
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database/databasetest"
+	"github.com/deezone/HydroBytes-BaseStation/internal/schema"
+
+	// Third-party packages
+	"github.com/jmoiron/sqlx"
+)
+
+// NewUnit creates a test database inside a Docker container. It creates the
+// required table structure but the database is otherwise empty.
+//
+// It does not return errors as this intended for testing only. Instead it will
+// call Fatal on the provided testing.T if anything goes wrong.
+//
+// It returns the database to use as well as a function to call at the end of
+// the test.
+func NewUnit(t *testing.T) (*sqlx.DB, func()) {
+	t.Helper()
+
+	c := databasetest.StartContainer(t)
+
+	db, err := database.Open(database.Config{
+		User:       "postgres",
+		Password:   "postgres",
+		Host:       c.Host,
+		Name:       "postgres",
+		DisableTLS: true,
+	})
+	if err != nil {
+		t.Fatalf("opening database connection: %v", err)
+	}
+
+	t.Log("waiting for database to be ready")
+
+	// Wait for the database to be ready. Wait 100ms longer between each attempt.
+	// Do not try more than 20 times.
+	var pingError error
+	maxAttempts := 20
+	for attempts := 1; attempts <= maxAttempts; attempts++ {
+		pingError = db.Ping()
+		if pingError == nil {
+			break
+		}
+		time.Sleep(time.Duration(attempts) * 100 * time.Millisecond)
+	}
+
+	if pingError != nil {
+		databasetest.DumpContainerLogs(t, c)
+		databasetest.StopContainer(t, c)
+		t.Fatalf("waiting for database to be ready: %v", pingError)
+	}
+
+	if err := schema.Migrate(db); err != nil {
+		databasetest.StopContainer(t, c)
+		t.Fatalf("migrating: %s", err)
+	}
+
+	// teardown is the function that should be invoked when the caller is done
+	// with the database.
+	teardown := func() {
+		t.Helper()
+		db.Close()
+		databasetest.StopContainer(t, c)
+	}
+
+	return db, teardown
+}


### PR DESCRIPTION
resolves #27       

### Description

This PR adds test coverage to the `station_types` business logic as well as functional tests for the API endpoints.

### How to Test

- [ ] confirm unit tests for `/internal/station_types/staion_types.com` are passing
```
> go test ./internal/station_types
ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_types	5.546s
```

- [ ] confirm functional tests for API endpoints are passing
```
> go test ./cmd/api/tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests	2.971s
```