### PR TITLE
Issue-29 Add context to request logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,18 @@ Migrations complete
 > go run ./cmd/admin seed
 Seeding complete
 ```
+
+#### Tests
+
+- Unit Tests
+
+```
+> go test ./internal/station_types
+ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_types	5.546s
+```
+
+- Functional tests
+```
+> go test ./cmd/api/tests
+ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests	2.971s
+```

--- a/cmd/api/internal/handlers/station_types.go
+++ b/cmd/api/internal/handlers/station_types.go
@@ -31,7 +31,7 @@ func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "decoding new station tyoe")
 	}
 
-	station_type, err := station_types.Create(st.db, nst, time.Now())
+	station_type, err := station_types.Create(r.Context(), st.db, nst, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "creating new station type")
 	}
@@ -51,7 +51,7 @@ func (st *StationTypes) Create(w http.ResponseWriter, r *http.Request) error {
  */
 func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) error {
 
-	list, err := station_types.List(st.db)
+	list, err := station_types.List(r.Context(), st.db)
 	if err != nil {
 		return errors.Wrap(err, "getting station tyoe list")
 	}
@@ -63,7 +63,7 @@ func (st *StationTypes) List(w http.ResponseWriter, r *http.Request) error {
 func (st *StationTypes) Retrieve(w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	station_type, err := station_types.Retrieve(st.db, id)
+	station_type, err := station_types.Retrieve(r.Context(), st.db, id)
 	if err != nil {
 		switch err {
 		case station_types.ErrNotFound:

--- a/cmd/api/tests/station_types_test.go
+++ b/cmd/api/tests/station_types_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	// Core Packages
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	// NOTE: Models should not be imported, we want to test the exact JSON. We
+	// make the comparison process easier using the go-cmp library.
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/cmd/api/internal/handlers"
+	"github.com/deezone/HydroBytes-BaseStation/internal/schema"
+	"github.com/deezone/HydroBytes-BaseStation/internal/tests"
+
+	// Third-party packages
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestStationTypes runs a series of tests to exercise StationTypes behavior from the
+// API level. The subtests all share the same database and application for
+// speed and convenience. The downside is the order the tests are run matters.
+// One test may break if other tests are not run before it. If a particular
+// subtest needs a fresh instance of the application it can make it or it
+// should be its own Test* function.
+func TestStationTypes(t *testing.T) {
+	db, teardown := tests.NewUnit(t)
+	defer teardown()
+
+	if err := schema.Seed(db); err != nil {
+		t.Fatal(err)
+	}
+
+	log := log.New(os.Stderr, "TEST : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+
+	tests := StationTypesTests{app: handlers.API(db, log)}
+
+	t.Run("List", tests.List)
+	t.Run("StationTypesCRUD", tests.StationTypesCRUD)
+}
+
+// StationTypesTests holds methods for each station types subtest. This type allows
+// passing dependencies for tests while still providing a convenient syntax
+// when subtests are registered.
+type StationTypesTests struct {
+	app http.Handler
+}
+
+func (st *StationTypesTests) List(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/station-types", nil)
+	resp := httptest.NewRecorder()
+
+	st.app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("getting: expected status code %v, got %v", http.StatusOK, resp.Code)
+	}
+
+	var list []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decoding: %s", err)
+	}
+
+	expected := []map[string]interface{}{
+		{
+			"id":           "a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+			"name":         "Base",
+			"description":  "Coordinator for all station types - monitor, command and control. Access point to public Intenet.",
+			"date_created": "2021-01-01T00:00:01.000001Z",
+			"date_updated": "2021-01-01T00:00:01.000001Z",
+		},
+		{
+			"id":           "72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
+			"name":         "Water",
+			"description":  "Management of water resources. Controls water levels in resavour and impliments irrigation.",
+			"date_created": "2021-01-01T00:00:02.000001Z",
+			"date_updated": "2021-01-01T00:00:02.000001Z",
+		},
+		{
+			"id":           "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
+			"name":         "Plant",
+			"description":  "Monitors and reports plant health.",
+			"date_created": "2021-01-01T00:00:03.000001Z",
+			"date_updated": "2021-01-01T00:00:03.000001Z",
+		},
+	}
+
+	if diff := cmp.Diff(expected, list); diff != "" {
+		t.Fatalf("Response did not match expected. Diff:\n%s", diff)
+	}
+}
+
+func (st *StationTypesTests) StationTypesCRUD(t *testing.T) {
+	var actual map[string]interface{}
+
+	{ // CREATE
+		body := strings.NewReader(`{"name":"stationtype0","description":"Test description 0"}`)
+
+		req := httptest.NewRequest("POST", "/v1/station-types", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+
+		st.app.ServeHTTP(resp, req)
+
+		if http.StatusCreated != resp.Code {
+			t.Fatalf("posting: expected status code %v, got %v", http.StatusCreated, resp.Code)
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&actual); err != nil {
+			t.Fatalf("decoding: %s", err)
+		}
+
+		if actual["id"] == "" || actual["id"] == nil {
+			t.Fatal("expected non-empty station_types id")
+		}
+		if actual["date_created"] == "" || actual["date_created"] == nil {
+			t.Fatal("expected non-empty station_types date_created")
+		}
+		if actual["date_updated"] == "" || actual["date_updated"] == nil {
+			t.Fatal("expected non-empty station_types date_updated")
+		}
+
+		expected := map[string]interface{}{
+			"id":           actual["id"],
+			"date_created": actual["date_created"],
+			"date_updated": actual["date_updated"],
+			"name":         "stationtype0",
+			"description":  "Test description 0",
+		}
+
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Fatalf("Response did not match expected. Diff:\n%s", diff)
+		}
+	}
+
+	{ // READ
+		url := fmt.Sprintf("/v1/station-types/%s", actual["id"])
+		req := httptest.NewRequest("GET", url, nil)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+
+		st.app.ServeHTTP(resp, req)
+
+		if http.StatusOK != resp.Code {
+			t.Fatalf("retrieving: expected status code %v, got %v", http.StatusOK, resp.Code)
+		}
+
+		var fetched map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&fetched); err != nil {
+			t.Fatalf("decoding: %s", err)
+		}
+
+		// Fetched station type should match the one created.
+		if diff := cmp.Diff(actual, fetched); diff != "" {
+			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
+		}
+	}
+}

--- a/internal/station_types/station_types.go
+++ b/internal/station_types/station_types.go
@@ -2,6 +2,7 @@ package station_types
 
 import (
 	// Core packages
+	"context"       // https://golang.org/pkg/context
 	"database/sql"
 	"time"
 
@@ -21,8 +22,8 @@ var (
 )
 
 // Create adds a StationType to the database. It returns the created StationTypes with
-// fields like ID and DateCreated populated..
-func Create(db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, error) {
+// fields like ID and DateCreated populated.
+func Create(ctx context.Context, db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, error) {
 	st := StationTypes{
 		Id:          uuid.New().String(),
 		Name:        nst.Name,
@@ -36,7 +37,7 @@ func Create(db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, err
 		  (id, name, description, date_created, date_updated)
 		VALUES ($1, $2, $3, $4, $5)`
 
-	_, err := db.Exec(q,
+	_, err := db.ExecContext(ctx, q,
 		st.Id,
 		st.Name,
 		st.Description,
@@ -52,7 +53,7 @@ func Create(db *sqlx.DB, nst NewStationTypes, now time.Time) (*StationTypes, err
 }
 
 // List gets all StationTypes from the database.
-func List(db *sqlx.DB) ([]StationTypes, error) {
+func List(ctx context.Context, db *sqlx.DB) ([]StationTypes, error) {
 	station_types := []StationTypes{}
 
 	const q = `
@@ -60,7 +61,7 @@ func List(db *sqlx.DB) ([]StationTypes, error) {
 			id, name, description, date_created, date_updated
 		FROM station_types`
 
-	if err := db.Select(&station_types, q); err != nil {
+	if err := db.SelectContext(ctx, &station_types, q); err != nil {
 		return nil, errors.Wrap(err, "selecting station types")
 	}
 
@@ -68,7 +69,7 @@ func List(db *sqlx.DB) ([]StationTypes, error) {
 }
 
 // Retrieve gets a specific StationType from the database.
-func Retrieve(db *sqlx.DB, id string) (*StationTypes, error) {
+func Retrieve(ctx context.Context, db *sqlx.DB, id string) (*StationTypes, error) {
 	if _, err := uuid.Parse(id); err != nil {
 		return nil, ErrInvalidID
 	}
@@ -81,7 +82,7 @@ func Retrieve(db *sqlx.DB, id string) (*StationTypes, error) {
 		FROM station_types
 		WHERE id = $1`
 
-	if err := db.Get(&st, q, id); err != nil {
+	if err := db.GetContext(ctx, &st, q, id); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrNotFound
 		}

--- a/internal/station_types/station_types_test.go
+++ b/internal/station_types/station_types_test.go
@@ -1,6 +1,7 @@
 package station_types_test
 
 import (
+	"context"
 	// Core packages
 	"testing"
 	"time"
@@ -23,13 +24,14 @@ func TestStationTypesCreateRetrieve(t *testing.T) {
 		Description: "Coordinator for all station types - monitor, command and control. Access point to public Intenet.",
 	}
 	now := time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC)
+	ctx := context.Background()
 
-	st0, err := station_types.Create(db, newP, now)
+	st0, err := station_types.Create(ctx, db, newP, now)
 	if err != nil {
 		t.Fatalf("creating station type st0: %s", err)
 	}
 
-	st1, err := station_types.Retrieve(db, st0.Id)
+	st1, err := station_types.Retrieve(ctx, db, st0.Id)
 	if err != nil {
 		t.Fatalf("getting station type p0: %s", err)
 	}
@@ -47,7 +49,9 @@ func TestStationTypesList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sts, err := station_types.List(db)
+	ctx := context.Background()
+
+	sts, err := station_types.List(ctx, db)
 	if err != nil {
 		t.Fatalf("listing station types: %s", err)
 	}


### PR DESCRIPTION
resolves #29        

### Description

This PR adds support for "context" to requests. Things like interrupt signals will result in immedate ending of processes.

### How to Test

- [x] Ensure all endpoints continue to respond as expected
- [x] Ensure all tests pass
```
> go test ./internal/station_types
ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_types	(cached)

> go test ./cmd/api/tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests	(cached)
dee in ~/projects/HydroBytes-BaseStation git HydroBytes-BaseStation/. Issue-29_context  > ls -la
```