### PR TITLE
Issue 31 add station type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ courses at **[Ardan Labs](https://education.ardanlabs.com/collections?category=c
 ```
 
 - supported requests to `localhost:8000`:
-  - `GET /v1/station-types`
-  - `GET /v1/station-type/{id}`
+  - `GET  /v1/station-types`
+  - `GET  /v1/station-type/{id}`
   - `POST /v1/station-type`
+  - `GET  /v1/station-type/{station-type-id}/stations`
+  - `POST /v1/station-type/{station-type-id}/station`
 
 #### Admin tools
 
@@ -84,15 +86,23 @@ Seeding complete
 
 #### Tests
 
-- Unit Tests
+- **Unit Tests**
 
 ```
 > go test ./internal/station_type
-ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	5.546s
+ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	6.805s
 ```
 
-- Functional tests
+NOTE: test coverage reports:
 ```
+alais gotwc='go test -coverprofile=coverage.out && go tool cover -html=coverage.out && rm coverage.out'
+```
+
+- **Functional tests**
+```
+# bust cache
+> go clean -testcache
+
 > go test ./cmd/api/tests
-ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests	2.971s
+ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests. 6.373s
 ```

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -24,7 +24,7 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 	app.Handle(http.MethodPost, "/v1/station-type", st.Create)
 
 	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
-	app.Handle(http.MethodGet, "/v1/station-type/{id}/station", st.ListStations)
+	app.Handle(http.MethodGet, "/v1/station-type/{id}/stations", st.ListStations)
 
 	return app
 }

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -23,5 +23,8 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 	app.Handle(http.MethodGet, "/v1/station-type/{id}", st.Retrieve)
 	app.Handle(http.MethodPost, "/v1/station-type", st.Create)
 
+	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
+	app.Handle(http.MethodGet, "/v1/station-type/{id}/station", st.ListStations)
+
 	return app
 }

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -12,8 +12,8 @@ import (
 
 	// Third party packages
 	"github.com/go-chi/chi"
-	"github.com/pkg/errors"
 	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
 )
 
 type StationType struct {
@@ -28,15 +28,15 @@ func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
 	var nst station_type.NewStationType
 
 	if err := web.Decode(r, &nst); err != nil {
-		return errors.Wrap(err, "decoding new station tyoe")
+		return errors.Wrap(err, "decoding new station type")
 	}
 
-	new_type, err := station_type.Create(r.Context(), st.db, nst, time.Now())
+	newType, err := station_type.Create(r.Context(), st.db, nst, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "creating new station type")
 	}
 
-	return web.Respond(w, &new_type, http.StatusCreated)
+	return web.Respond(w, &newType, http.StatusCreated)
 }
 
 /**
@@ -53,7 +53,7 @@ func (st *StationType) List(w http.ResponseWriter, r *http.Request) error {
 
 	list, err := station_type.List(r.Context(), st.db)
 	if err != nil {
-		return errors.Wrap(err, "getting station tyoe list")
+		return errors.Wrap(err, "getting station type list")
 	}
 
 	return web.Respond(w, list, http.StatusOK)

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -31,12 +31,12 @@ func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "decoding new station type")
 	}
 
-	newType, err := station_type.Create(r.Context(), st.db, nst, time.Now())
+	stationType, err := station_type.Create(r.Context(), st.db, nst, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "creating new station type")
 	}
 
-	return web.Respond(w, &newType, http.StatusCreated)
+	return web.Respond(w, &stationType, http.StatusCreated)
 }
 
 /**
@@ -63,7 +63,7 @@ func (st *StationType) List(w http.ResponseWriter, r *http.Request) error {
 func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	types, err := station_type.Retrieve(r.Context(), st.db, id)
+	stationTypes, err := station_type.Retrieve(r.Context(), st.db, id)
 	if err != nil {
 		switch err {
 		case station_type.ErrNotFound:
@@ -75,7 +75,7 @@ func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(w, types, http.StatusOK)
+	return web.Respond(w, stationTypes, http.StatusOK)
 }
 
 // AddStation creates a new Station for a particular station_type. It looks for a JSON
@@ -83,12 +83,12 @@ func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error {
 	var ns station_type.NewStation
 	if err := web.Decode(r, &ns); err != nil {
-		return errors.Wrap(err, "decoding new sale")
+		return errors.Wrap(err, "decoding new station")
 	}
 
-	productID := chi.URLParam(r, "id")
+	stationTypeId := chi.URLParam(r, "id")
 
-	station, err := station_type.AddStation(r.Context(), st.db, ns, productID, time.Now())
+	station, err := station_type.AddStation(r.Context(), st.db, ns, stationTypeId, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "adding new sale")
 	}

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -77,3 +77,33 @@ func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 
 	return web.Respond(w, types, http.StatusOK)
 }
+
+// AddStation creates a new Station for a particular station_type. It looks for a JSON
+// object in the request body. The full model is returned to the caller.
+func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error {
+	var ns station_type.NewStation
+	if err := web.Decode(r, &ns); err != nil {
+		return errors.Wrap(err, "decoding new sale")
+	}
+
+	productID := chi.URLParam(r, "id")
+
+	station, err := station_type.AddStation(r.Context(), st.db, ns, productID, time.Now())
+	if err != nil {
+		return errors.Wrap(err, "adding new sale")
+	}
+
+	return web.Respond(w, station, http.StatusCreated)
+}
+
+// ListSales gets all sales for a particular product.
+func (st *StationType) ListStations(w http.ResponseWriter, r *http.Request) error {
+	id := chi.URLParam(r, "id")
+
+	list, err := station_type.ListStations(r.Context(), st.db, id)
+	if err != nil {
+		return errors.Wrap(err, "getting sales list")
+	}
+
+	return web.Respond(w, list, http.StatusOK)
+}

--- a/cmd/api/tests/station_test.go
+++ b/cmd/api/tests/station_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	// Core Packages
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -22,13 +21,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// TestStationType runs a series of tests to exercise StationTypes behavior from the
+// TestStation runs a series of tests to exercise Station behavior from the
 // API level. The subtests all share the same database and application for
 // speed and convenience. The downside is the order the tests are run matters.
 // One test may break if other tests are not run before it. If a particular
 // subtest needs a fresh instance of the application it can make it or it
 // should be its own Test* function.
-func TestStationType(t *testing.T) {
+func TestStation(t *testing.T) {
 	db, teardown := tests.NewUnit(t)
 	defer teardown()
 
@@ -38,21 +37,23 @@ func TestStationType(t *testing.T) {
 
 	log := log.New(os.Stderr, "TEST : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
 
-	tests := StationTypeTests{app: handlers.API(db, log)}
+	tests := StationTests{app: handlers.API(db, log)}
 
-	t.Run("List", tests.List)
-	// t.Run("StationTypeCRUD", tests.StationTypeCRUD)
+	t.Run("ListStations", tests.ListStations)
+	// t.Run("StationCRUD", tests.StationCRUD)
 }
 
-// StationTypesTests holds methods for each station types subtest. This type allows
+// StationTests holds methods for each station subtest. This type allows
 // passing dependencies for tests while still providing a convenient syntax
 // when subtests are registered.
-type StationTypeTests struct {
+type StationTests struct {
 	app http.Handler
 }
 
-func (st *StationTypeTests) List(t *testing.T) {
-	req := httptest.NewRequest("GET", "/v1/station-types", nil)
+func (st *StationTests) ListStations(t *testing.T) {
+
+	// Get list of stations by the Plant StationType (5c86bbaa-4ef8-11eb-ae93-0242ac130002) as defined in the seed data
+	req := httptest.NewRequest("GET", "/v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/stations", nil)
 	resp := httptest.NewRecorder()
 
 	st.app.ServeHTTP(resp, req)
@@ -68,28 +69,34 @@ func (st *StationTypeTests) List(t *testing.T) {
 
 	expected := []map[string]interface{}{
 		{
-			"id":           "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
-			"name":         "Plant",
-			"description":  "Monitors and reports plant health.",
-			"stations":     float64(3),
-			"date_created": "2021-01-01T00:00:03.000001Z",
-			"date_updated": "2021-01-01T00:00:03.000001Z",
+			"id":              "f676f266-590c-11eb-ae93-0242ac130002",
+			"station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
+			"name":            "Plant Station One",
+			"description":     "Some description of Plant Station One",
+			"location_x":      float64(3),
+			"location_y":      float64(3),
+			"date_created":    "2021-01-01T00:00:03.000001Z",
+			"date_updated":    "2021-01-01T00:00:03.000001Z",
 		},
 		{
-			"id":           "a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
-			"name":         "Base",
-			"description":  "Coordinator for all station types - monitor, command and control. Access point to public Intenet.",
-			"stations":     float64(1),
-			"date_created": "2021-01-01T00:00:01.000001Z",
-			"date_updated": "2021-01-01T00:00:01.000001Z",
+			"id":              "feaa0806-590c-11eb-ae93-0242ac130002",
+			"station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
+			"name":            "Plant Station Two",
+			"description":     "Some description of Plant Station Two",
+			"location_x":      float64(4),
+			"location_y":      float64(3),
+			"date_created":    "2021-01-01T00:00:04.000001Z",
+			"date_updated":    "2021-01-01T00:00:04.000001Z",
 		},
 		{
-			"id":           "72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
-			"name":         "Water",
-			"description":  "Management of water resources. Controls water levels in resavour and impliments irrigation.",
-			"stations":     float64(1),
-			"date_created": "2021-01-01T00:00:02.000001Z",
-			"date_updated": "2021-01-01T00:00:02.000001Z",
+			"id":              "0690d086-590d-11eb-ae93-0242ac130002",
+			"station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
+			"name":            "Plant Station Three",
+			"description":     "Some description of Plant Station Three",
+			"location_x":      float64(5),
+			"location_y":      float64(3),
+			"date_created":    "2021-01-01T00:00:05.000001Z",
+			"date_updated":    "2021-01-01T00:00:05.000001Z",
 		},
 	}
 
@@ -98,13 +105,14 @@ func (st *StationTypeTests) List(t *testing.T) {
 	}
 }
 
-func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
+func (st *StationTests) StationCRUD(t *testing.T) {
 	var actual map[string]interface{}
 
 	{ // CREATE
-		body := strings.NewReader(`{"name":"stationtype0","description":"Test description 0"}`)
+		body := strings.NewReader(`{"name":"station0","description":"Test description 0", "location_x":123, "location_y": 789}`)
 
-		req := httptest.NewRequest("POST", "/v1/station-type", body)
+		// Create new station of type Plant StationType (5c86bbaa-4ef8-11eb-ae93-0242ac130002) as defined in the seed data
+		req := httptest.NewRequest("POST", "/v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/station", body)
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
@@ -132,35 +140,14 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 			"id":           actual["id"],
 			"date_created": actual["date_created"],
 			"date_updated": actual["date_updated"],
-			"name":         "stationtype0",
+			"name":         "station0",
 			"description":  "Test description 0",
+			"location_x":   float64(123),
+			"location_y":   float64(789),
 		}
 
 		if diff := cmp.Diff(expected, actual); diff != "" {
 			t.Fatalf("Response did not match expected. Diff:\n%s", diff)
-		}
-	}
-
-	{ // READ
-		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
-		req := httptest.NewRequest("GET", url, nil)
-		req.Header.Set("Content-Type", "application/json")
-		resp := httptest.NewRecorder()
-
-		st.app.ServeHTTP(resp, req)
-
-		if http.StatusOK != resp.Code {
-			t.Fatalf("retrieving: expected status code %v, got %v", http.StatusOK, resp.Code)
-		}
-
-		var fetched map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&fetched); err != nil {
-			t.Fatalf("decoding: %s", err)
-		}
-
-		// Fetched station type should match the one created.
-		if diff := cmp.Diff(actual, fetched); diff != "" {
-			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
 		}
 	}
 }

--- a/cmd/api/tests/station_type_test.go
+++ b/cmd/api/tests/station_type_test.go
@@ -41,7 +41,7 @@ func TestStationType(t *testing.T) {
 	tests := StationTypeTests{app: handlers.API(db, log)}
 
 	t.Run("List", tests.List)
-	t.Run("StationTypesCRUD", tests.StationTypeCRUD)
+	t.Run("StationTypeCRUD", tests.StationTypeCRUD)
 }
 
 // StationTypesTests holds methods for each station types subtest. This type allows

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	// Third-party packages
 	"github.com/GuiaBolso/darwin"
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -36,8 +36,8 @@ CREATE TABLE station (
 	station_type_id UUID,
 	name            TEXT,
 	description     TEXT,
-	x_location      INT,
-	y_location      INT,
+	location_x      INT,
+	location_y      INT,
 	date_created    TIMESTAMP,
 	date_updated    TIMESTAMP,
 

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -27,7 +27,24 @@ CREATE TABLE station_type (
 	PRIMARY KEY (id)
 );`,
 	},
+	{
+		Version:     2,
+		Description: "Add station",
+		Script: `
+CREATE TABLE station (
+	id              UUID,
+	station_type_id UUID,
+	name            TEXT,
+	description     TEXT,
+	x_location      INT,
+	y_location      INT,
+	date_created    TIMESTAMP,
+	date_updated    TIMESTAMP,
 
+	PRIMARY KEY (id),
+	FOREIGN KEY (station_type_id) REFERENCES station_type(id) ON DELETE CASCADE
+);`,
+	},
 }
 
 // Migrate attempts to bring the schema for db up to date with the migrations

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -25,7 +25,11 @@ INSERT INTO station_type (id, name, description, date_created, date_updated) VAL
 	ON CONFLICT DO NOTHING;
 
 INSERT INTO station (id, station_type_id, name, description, location_x, location_y, date_created, date_updated) VALUES
-	('33539d91-7823-4169-8fed-31494ac2c22a', 'a2b0639f-2cc6-44b8-b97b-15d69dbb511e', 'Base Station One', 'Some description of Base Station One', 1, 1)
+	('ddd3f222-590c-11eb-ae93-0242ac130002', 'a2b0639f-2cc6-44b8-b97b-15d69dbb511e', 'Base Station One', 'Some description of Base Station One', 1, 1, '2021-01-01 00:00:01.000001+00', '2021-01-01 00:00:01.000001+00'),
+    ('ee72a90c-590c-11eb-ae93-0242ac130002', '72f8b983-3eb4-48db-9ed0-e45cc6bd716b', 'Water Station One', 'Some description of Water Station One', 2, 2, '2021-01-01 00:00:02.000001+00', '2021-01-01 00:00:02.000001+00'),
+    ('f676f266-590c-11eb-ae93-0242ac130002', '5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant Station One', 'Some description of Plant Station One', 3, 3, '2021-01-01 00:00:03.000001+00', '2021-01-01 00:00:03.000001+00'),
+    ('feaa0806-590c-11eb-ae93-0242ac130002', '5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant Station Two', 'Some description of Plant Station Two', 4, 3, '2021-01-01 00:00:04.000001+00', '2021-01-01 00:00:04.000001+00'),
+    ('0690d086-590d-11eb-ae93-0242ac130002', '5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant Station Three', 'Some description of Plant Station Three', 5, 3, '2021-01-01 00:00:05.000001+00', '2021-01-01 00:00:05.000001+00')
 	ON CONFLICT DO NOTHING;
 `
 

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -23,6 +23,10 @@ INSERT INTO station_type (id, name, description, date_created, date_updated) VAL
 	('72f8b983-3eb4-48db-9ed0-e45cc6bd716b', 'Water', 'Management of water resources. Controls water levels in resavour and impliments irrigation.', '2021-01-01 00:00:02.000001+00', '2021-01-01 00:00:02.000001+00'),
     ('5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant', 'Monitors and reports plant health.', '2021-01-01 00:00:03.000001+00', '2021-01-01 00:00:03.000001+00')
 	ON CONFLICT DO NOTHING;
+
+INSERT INTO station (id, station_type_id, name, description, location_x, location_y, date_created, date_updated) VALUES
+	('33539d91-7823-4169-8fed-31494ac2c22a', 'a2b0639f-2cc6-44b8-b97b-15d69dbb511e', 'Base Station One', 'Some description of Base Station One', 1, 1)
+	ON CONFLICT DO NOTHING;
 `
 
 // Seed runs the set of seed-data queries against db. The queries are ran in a

--- a/internal/station_type/models.go
+++ b/internal/station_type/models.go
@@ -18,6 +18,7 @@ type StationType struct {
 	Id          string    `db:"id"           json:"id"`
 	Name        string    `db:"name"         json:"name"`
 	Description string    `db:"description"  json:"description"`
+	Stations    int       `db:"stations"     json:"stations"`
 	DateCreated time.Time `db:"date_created" json:"date_created"`
 	DateUpdated time.Time `db:"date_updated" json:"date_updated"`
 }

--- a/internal/station_type/models.go
+++ b/internal/station_type/models.go
@@ -8,7 +8,7 @@ import (
 /**
  * StationType is a type of station in the automated garden system.
  *
- * Note: use of "stuct tags" (ex: `json:"id"`) to manage the names of properties to be lowercase and snake_case. Due to
+ * Note: use of "struct tags" (ex: `json:"id"`) to manage the names of properties to be lowercase and snake_case. Due to
  * the use of case for visibility in Go "id" rather and "Id" would result in the value being excluded in the JSON
  * response as the encoding/json package is external to this package.
  *
@@ -26,4 +26,24 @@ type StationType struct {
 type NewStationType struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
+}
+
+// Station is a station that is defined as one of the station types in StationType.
+type Station struct {
+	Id            string    `db:"id"              json:"id"`
+	StationTypeId string    `db:"station_type_id" json:"station_type_id"`
+	Name          string    `db:"name"            json:"name"`
+	Description   string    `db:"description"     json:"description"`
+	LocationX     int       `db:"location_x"      json:"location_x"`
+	LocationY     int       `db:"location_y"      json:"location_y"`
+	DateCreated   time.Time `db:"date_created"    json:"date_created"`
+	DateUpdated   time.Time `db:"date_updated"    json:"date_updated"`
+}
+
+// NewStation is a what we require from clients when adding a BaseStation.
+type NewStation struct {
+	Name          string    `db:"name"            json:"name"`
+	Description   string    `db:"description"     json:"description"`
+	LocationX     int       `db:"location_x"      json:"location_x"`
+	LocationY     int       `db:"location_y"      json:"location_y"`
 }

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -11,35 +11,41 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AddSale records a sales transaction for a single Product.
+// AddStation adds a station of a specific StationType.
 func AddStation(ctx context.Context, db *sqlx.DB, ns NewStation, stationTypeID string, now time.Time) (*Station, error) {
 	s := Station{
 		Id:            uuid.New().String(),
 		StationTypeId: stationTypeID,
 		Name:          ns.Name,
 		Description:   ns.Description,
+		LocationX:     ns.LocationX,
+		LocationY:     ns.LocationY,
 		DateCreated:   now,
 		DateUpdated:   now,
 	}
 
 	const q = `INSERT INTO station
-		(station_id, station_type_id, name, description, location_x, location_y, date_created, date_updated)
-		VALUES ($1, $2, $3, $4, $5, $6)`
+		(id, station_type_id, name, description, location_x, location_y, date_created, date_updated)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 
 	_, err := db.ExecContext(ctx, q,
-		s.Id, s.StationTypeId,
-		s.Name, s.Description,
-		s.LocationX, s.LocationY,
-		s.DateCreated, s.DateUpdated,
+		s.Id,
+		s.StationTypeId,
+		s.Name,
+		s.Description,
+		s.LocationX,
+		s.LocationY,
+		s.DateCreated,
+		s.DateUpdated,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "inserting sale")
+		return nil, errors.Wrap(err, "inserting station")
 	}
 
 	return &s, nil
 }
 
-// ListStation gives all Stations for a StationType.
+// ListStations gives all Stations for a StationType.
 func ListStations(ctx context.Context, db *sqlx.DB, stationTypeID string) ([]Station, error) {
 	stations := []Station{}
 

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -1,0 +1,63 @@
+package station_type
+
+import (
+	// Core packages
+	"context"
+	"time"
+
+	// Third-party packages
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+// AddSale records a sales transaction for a single Product.
+func AddStation(ctx context.Context, db *sqlx.DB, ns NewStation, stationTypeID string, now time.Time) (*Station, error) {
+	s := Station{
+		Id:            uuid.New().String(),
+		StationTypeId: stationTypeID,
+		Name:          ns.Name,
+		Description:   ns.Description,
+		DateCreated:   now,
+		DateUpdated:   now,
+	}
+
+	const q = `INSERT INTO station
+		(station_id, station_type_id, name, description, location_x, location_y, date_created, date_updated)
+		VALUES ($1, $2, $3, $4, $5, $6)`
+
+	_, err := db.ExecContext(ctx, q,
+		s.Id, s.StationTypeId,
+		s.Name, s.Description,
+		s.LocationX, s.LocationY,
+		s.DateCreated, s.DateUpdated,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "inserting sale")
+	}
+
+	return &s, nil
+}
+
+// ListStation gives all Stations for a StationType.
+func ListStations(ctx context.Context, db *sqlx.DB, stationTypeID string) ([]Station, error) {
+	stations := []Station{}
+
+	const q = `
+      SELECT
+        id,
+        station_type_id,
+        name, description,
+        location_x,
+        location_y,
+        date_created,
+        date_updated
+      FROM station
+      WHERE station_type_id = $1`
+
+	if err := db.SelectContext(ctx, &stations, q, stationTypeID); err != nil {
+		return nil, errors.Wrap(err, "selecting stations")
+	}
+
+	return stations, nil
+}

--- a/internal/station_type/station_test.go
+++ b/internal/station_type/station_test.go
@@ -1,0 +1,79 @@
+package station_type_test
+
+import (
+	// Core packages
+	"context"
+	"testing"
+	"time"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/station_type"
+	"github.com/deezone/HydroBytes-BaseStation/internal/tests"
+)
+
+func TestStation(t *testing.T) {
+	db, teardown := tests.NewUnit(t)
+	defer teardown()
+
+	now := time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	ctx := context.Background()
+
+	// Create two station types to work with.
+	newStationTypeOne := station_type.NewStationType{
+		Name:     "Station Type Name One",
+		Description: "Station type one description test",
+	}
+
+	stationTypeOne, err := station_type.Create(ctx, db, newStationTypeOne, now)
+	if err != nil {
+		t.Fatalf("creating station type one: %s", err)
+	}
+
+	newStationTypeTwo := station_type.NewStationType{
+		Name:     "Station Type Name Two",
+		Description: "Station type two description test",
+
+	}
+	stationTypeTwo, err := station_type.Create(ctx, db, newStationTypeTwo, now)
+	if err != nil {
+		t.Fatalf("creating station type two: %s", err)
+	}
+
+	{ // Add and list
+
+		ns := station_type.NewStation{
+			Name: "",
+			Description: "",
+			LocationX: 7,
+			LocationY: 6,
+		}
+
+		s, err := station_type.AddStation(ctx, db, ns, stationTypeOne.Id, now)
+		if err != nil {
+			t.Fatalf("adding test station one: %s", err)
+		}
+
+		// StationTypeOne should show the 1 station.
+		stations, err := station_type.ListStations(ctx, db, stationTypeOne.Id)
+		if err != nil {
+			t.Fatalf("listing stations: %s", err)
+		}
+		if exp, got := 1, len(stations); exp != got {
+			t.Fatalf("expected station list size %v, got %v", exp, got)
+		}
+
+		if exp, got := s.Id, stations[0].Id; exp != got {
+			t.Fatalf("expected first station Id %v, got %v", exp, got)
+		}
+
+		// StationTypeTwo should have 0 stations.
+		stations, err = station_type.ListStations(ctx, db, stationTypeTwo.Id)
+		if err != nil {
+			t.Fatalf("listing stations: %s", err)
+		}
+		if exp, got := 0, len(stations); exp != got {
+			t.Fatalf("expected station list size %v, got %v", exp, got)
+		}
+	}
+}

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -58,8 +58,15 @@ func List(ctx context.Context, db *sqlx.DB) ([]StationType, error) {
 
 	const q = `
 		SELECT
-			id, name, description, date_created, date_updated
-		FROM station_type`
+			station_type.id,
+			station_type.name,
+			station_type.description,
+			COUNT(station.id) AS stations,
+			station_type.date_created,
+			station_type.date_updated
+		FROM station_type
+		  LEFT JOIN station ON station_type.id = station.station_type_id
+		GROUP BY station_type.id`
 
 	if err := db.SelectContext(ctx, &station_type, q); err != nil {
 		return nil, errors.Wrap(err, "selecting station types")
@@ -78,9 +85,16 @@ func Retrieve(ctx context.Context, db *sqlx.DB, id string) (*StationType, error)
 
 	const q = `
 		SELECT
-			id, name, description, date_created, date_updated
+			station_type.id,
+			station_type.name,
+			station_type.description,
+			COUNT(station.id) AS stations,
+			station_type.date_created,
+			station_type.date_updated
 		FROM station_type
-		WHERE id = $1`
+		  LEFT JOIN station ON station_type.id = station.station_type_id
+		WHERE station_type.id = $1
+		GROUP BY station_type.id`
 
 	if err := db.GetContext(ctx, &st, q, id); err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -14,14 +14,14 @@ import (
 
 // Predefined errors identify expected failure conditions.
 var (
-	// ErrNotFound is used when a specific StationTypes is requested but does not exist.
+	// ErrNotFound is used when a specific StationType is requested but does not exist.
 	ErrNotFound = errors.New("station type not found")
 
 	// ErrInvalidID is used when an invalid UUID is provided.
 	ErrInvalidID = errors.New("ID is not in its proper UUID format")
 )
 
-// Create adds a StationType to the database. It returns the created StationTypes with
+// Create adds a StationType to the database. It returns the created StationType with
 // fields like ID and DateCreated populated.
 func Create(ctx context.Context, db *sqlx.DB, nst NewStationType, now time.Time) (*StationType, error) {
 	st := StationType{
@@ -52,7 +52,7 @@ func Create(ctx context.Context, db *sqlx.DB, nst NewStationType, now time.Time)
 	return &st, nil
 }
 
-// List gets all StationTypes from the database.
+// List gets all StationType from the database.
 func List(ctx context.Context, db *sqlx.DB) ([]StationType, error) {
 	station_type := []StationType{}
 

--- a/internal/station_type/station_type_test.go
+++ b/internal/station_type/station_type_test.go
@@ -56,6 +56,6 @@ func TestStationTypeList(t *testing.T) {
 		t.Fatalf("listing station types: %s", err)
 	}
 	if exp, got := 3, len(sts); exp != got {
-		t.Fatalf("expected station types list size %v, got %v", exp, got)
+		t.Fatalf("expected station type list size %v, got %v", exp, got)
 	}
 }

--- a/resources/postman_collection.json
+++ b/resources/postman_collection.json
@@ -106,14 +106,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station-types/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+					"raw": "{{SERVER}}/v1/station-type/fc935253-83af-47e7-a7c8-9f9ee182b34e",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"station-types",
-						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
+						"station-type",
+						"fc935253-83af-47e7-a7c8-9f9ee182b34e"
 					]
 				}
 			},
@@ -141,16 +141,21 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"Test Station\",\n\t\"description\": \"Test description\"\n}"
+					"raw": "{\n    \"name\": \"Test name3\",\n    \"description\": \"Test description3\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station-types",
+					"raw": "{{SERVER}}/v1/station-type",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"station-types"
+						"station-type"
 					]
 				}
 			},
@@ -181,13 +186,13 @@
 					"raw": "{\n\t\"name\": \"New Test Station\"\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station-types/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"station-types",
+						"station-type",
 						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
 					]
 				}
@@ -210,13 +215,13 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station-types/72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
+					"raw": "{{SERVER}}/v1/station-type/72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"station-types",
+						"station-type",
 						"72f8b983-3eb4-48db-9ed0-e45cc6bd716b"
 					]
 				}
@@ -239,13 +244,13 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station-types/a2b0639f-2cc6-44b8-b97b-15d69dbb511e/stations",
+					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e/stations",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"station-types",
+						"station-type",
 						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
 						"stations"
 					]


### PR DESCRIPTION
resolves #31         

### Description

This PR adds a second model - "BaseStation" as one of the "StationType"s.

Addition refactoring:

- [x] Rename model "StationTypes" to "StationType"
- [x] Add "Base" station model which is one of the of the  "StationType"s
- [x] Add endpoint to create "Base" station
- [x] Add endpoint to list "Stations" by "StationType". any "Base" station records should be included in the list
- [x] Update "StationType" response to include the number of Stations that exist for the StationType
- [ ] Update documentation to include `base-station` details

### How to Test

- [x] Confirm `station-type` endpoints continue to work
- Confirm `station` endpoints - `POST` and `GET` work
  - [ ] `GET v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/stations`
```
[
    {
        "id": "f676f266-590c-11eb-ae93-0242ac130002",
        "station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
        "name": "Plant Station One",
        "description": "Some description of Plant Station One",
        "location_x": 3,
        "location_y": 3,
        "date_created": "2021-01-01T00:00:03.000001Z",
        "date_updated": "2021-01-01T00:00:03.000001Z"
    },
    {
        "id": "feaa0806-590c-11eb-ae93-0242ac130002",
        "station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
        "name": "Plant Station Two",
        "description": "Some description of Plant Station Two",
        "location_x": 4,
        "location_y": 3,
        "date_created": "2021-01-01T00:00:04.000001Z",
        "date_updated": "2021-01-01T00:00:04.000001Z"
    },
    {
        "id": "0690d086-590d-11eb-ae93-0242ac130002",
        "station_type_id": "5c86bbaa-4ef8-11eb-ae93-0242ac130002",
        "name": "Plant Station Three",
        "description": "Some description of Plant Station Three",
        "location_x": 5,
        "location_y": 3,
        "date_created": "2021-01-01T00:00:05.000001Z",
        "date_updated": "2021-01-01T00:00:05.000001Z"
    }
]
```

  - [ ] `POST /v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e/station`
**BODY**
 ```
{
	"name": "Test Station Creation Two",
	"description": "Test station description two",
        "location_x": 3,
        "location_y": 5
}
```

**RESPONSE**
```
{
    "id": "0a454006-6c51-47e0-98e1-4dd043f39269",
    "station_type_id": "a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
    "name": "Test Station Creation Two",
    "description": "Test station description two",
    "location_x": 3,
    "location_y": 5,
    "date_created": "2021-01-17T23:02:55.205393-05:00",
    "date_updated": "2021-01-17T23:02:55.205393-05:00"
}
```

- Confirm tests pass:
- [ ] Unit tests:
```
go test ./internal/station_type
ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type
```
![image](https://user-images.githubusercontent.com/2119264/104871408-f2a63c80-5918-11eb-96d6-62b2606f506a.png)
![image](https://user-images.githubusercontent.com/2119264/104871451-0b165700-5919-11eb-84c6-90377cb5f4c1.png)

- [ ] Functional tests:
```
# bust cache
go clean -testcache

go test ./cmd/api/tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests. 6.373s
```

