### PR TITLE
Issue 37 UPDATE / DELETE station_type and station

### DIFF
--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -24,9 +24,10 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 	app.Handle(http.MethodPost, "/v1/station-type", st.Create)
 	app.Handle(http.MethodPut,  "/v1/station-type/{id}", st.Update)
 
-	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
 	app.Handle(http.MethodGet,  "/v1/station-type/{id}/stations", st.ListStations)
-	app.Handle(http.MethodGet,  "/v1/station/{id}", st.AdjustStation)
+	app.Handle(http.MethodGet,  "/v1/station/{id}", st.RetrieveStation)
+	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
+	app.Handle(http.MethodPut,  "/v1/station/{id}", st.AdjustStation)
 
 	return app
 }

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -19,15 +19,17 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 
 	st := StationType{db: db, log: log}
 
-	app.Handle(http.MethodGet,  "/v1/station-types", st.List)
-	app.Handle(http.MethodGet,  "/v1/station-type/{id}", st.Retrieve)
-	app.Handle(http.MethodPost, "/v1/station-type", st.Create)
-	app.Handle(http.MethodPut,  "/v1/station-type/{id}", st.Update)
+	app.Handle(http.MethodGet,    "/v1/station-types", st.List)
+	app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve)
+	app.Handle(http.MethodPost,   "/v1/station-type", st.Create)
+	app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update)
+	app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete)
 
-	app.Handle(http.MethodGet,  "/v1/station-type/{id}/stations", st.ListStations)
-	app.Handle(http.MethodGet,  "/v1/station/{id}", st.RetrieveStation)
-	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
-	app.Handle(http.MethodPut,  "/v1/station/{id}", st.AdjustStation)
+	app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations)
+	app.Handle(http.MethodGet,    "/v1/station/{id}", st.RetrieveStation)
+	app.Handle(http.MethodPost,   "/v1/station-type/{id}/station", st.AddStation)
+	app.Handle(http.MethodPut,    "/v1/station/{id}", st.AdjustStation)
+	app.Handle(http.MethodDelete, "/v1/station/{id}", st.DeleteStation)
 
 	return app
 }

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -19,12 +19,14 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 
 	st := StationType{db: db, log: log}
 
-	app.Handle(http.MethodGet, "/v1/station-types", st.List)
-	app.Handle(http.MethodGet, "/v1/station-type/{id}", st.Retrieve)
+	app.Handle(http.MethodGet,  "/v1/station-types", st.List)
+	app.Handle(http.MethodGet,  "/v1/station-type/{id}", st.Retrieve)
 	app.Handle(http.MethodPost, "/v1/station-type", st.Create)
+	app.Handle(http.MethodPut,  "/v1/station-type/{id}", st.Update)
 
 	app.Handle(http.MethodPost, "/v1/station-type/{id}/station", st.AddStation)
-	app.Handle(http.MethodGet, "/v1/station-type/{id}/stations", st.ListStations)
+	app.Handle(http.MethodGet,  "/v1/station-type/{id}/stations", st.ListStations)
+	app.Handle(http.MethodGet,  "/v1/station/{id}", st.AdjustStation)
 
 	return app
 }

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -85,7 +85,7 @@ func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
 
 	var update station_type.UpdateStationType
 	if err := web.Decode(r, &update); err != nil {
-		return errors.Wrap(err, "decoding product update")
+		return errors.Wrap(err, "decoding station type update")
 	}
 
 	if err := station_type.Update(r.Context(), st.db, id, update, time.Now()); err != nil {

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -39,6 +39,22 @@ func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
 	return web.Respond(w, &stationType, http.StatusCreated)
 }
 
+// Delete removes a single station type identified by an ID in the request URL.
+func (p *StationType) Delete(w http.ResponseWriter, r *http.Request) error {
+	id := chi.URLParam(r, "id")
+
+	if err := station_type.Delete(r.Context(), p.db, id); err != nil {
+		switch err {
+		case station_type.ErrInvalidID:
+			return web.NewRequestError(err, http.StatusBadRequest)
+		default:
+			return errors.Wrapf(err, "deleting station type %q", id)
+		}
+	}
+
+	return web.Respond(w, nil, http.StatusNoContent)
+}
+
 /**
  * List StationTypes is a basic HTTP Handler that lists all of the station types in the HydroByte Automated Garden system.
  * A Handler is also know as a "controller" in the MVC pattern.
@@ -122,6 +138,22 @@ func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	return web.Respond(w, station, http.StatusCreated)
+}
+
+// Delete removes a single station identified by an ID in the request URL.
+func (p *StationType) DeleteStation(w http.ResponseWriter, r *http.Request) error {
+	id := chi.URLParam(r, "id")
+
+	if err := station_type.DeleteStation(r.Context(), p.db, id); err != nil {
+		switch err {
+		case station_type.ErrInvalidID:
+			return web.NewRequestError(err, http.StatusBadRequest)
+		default:
+			return errors.Wrapf(err, "deleting station %q", id)
+		}
+	}
+
+	return web.Respond(w, nil, http.StatusNoContent)
 }
 
 // ListSales gets all sales for a particular product.

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -156,7 +156,7 @@ func (p *StationType) DeleteStation(w http.ResponseWriter, r *http.Request) erro
 	return web.Respond(w, nil, http.StatusNoContent)
 }
 
-// ListSales gets all sales for a particular product.
+// ListStations gets all sales for a particular station type.
 func (st *StationType) ListStations(w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
@@ -175,7 +175,7 @@ func (st *StationType) RetrieveStation(w http.ResponseWriter, r *http.Request) e
 	station, err := station_type.RetrieveStation(r.Context(), st.db, id)
 	if err != nil {
 		switch err {
-		case station_type.ErrNotFound:
+		case station_type.ErrStationNotFound:
 			return web.NewRequestError(err, http.StatusNotFound)
 		case station_type.ErrInvalidID:
 			return web.NewRequestError(err, http.StatusBadRequest)
@@ -199,7 +199,7 @@ func (st *StationType) AdjustStation(w http.ResponseWriter, r *http.Request) err
 
 	if err := station_type.AdjustStation(r.Context(), st.db, id, update, time.Now()); err != nil {
 		switch err {
-		case station_type.ErrNotFound:
+		case station_type.ErrStationNotFound:
 			return web.NewRequestError(err, http.StatusNotFound)
 		case station_type.ErrInvalidID:
 			return web.NewRequestError(err, http.StatusBadRequest)

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -59,7 +59,7 @@ func (st *StationType) List(w http.ResponseWriter, r *http.Request) error {
 	return web.Respond(w, list, http.StatusOK)
 }
 
-// Retrieve finds a single station type identified by an ID in the request URL.
+// Retrieve finds all stations of a station type identified by a station type ID in the request URL.
 func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 

--- a/cmd/api/tests/station_tests/station_test.go
+++ b/cmd/api/tests/station_tests/station_test.go
@@ -187,7 +187,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 
 		// Fetched station should match the one created.
 		if diff := cmp.Diff(actual, fetched); diff != "" {
-			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
+			t.Fatalf("Retrieved station should match created. Diff:\n%s", diff)
 		}
 	}
 

--- a/cmd/api/tests/station_tests/station_test.go
+++ b/cmd/api/tests/station_tests/station_test.go
@@ -221,13 +221,14 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		}
 
 		want := map[string]interface{}{
-			"id":           actual["id"],
-			"date_created": actual["date_created"],
-			"date_updated": updated["date_updated"],
-			"name":         "UPDATED station0",
-			"description":  "UPDATED Test description 0",
-			"location_x":   float64(456),
-			"location_y":   float64(123),
+			"id":              actual["id"],
+			"date_created":    actual["date_created"],
+			"date_updated":    updated["date_updated"],
+			"name":            "UPDATED station0",
+			"description":     "UPDATED Test description 0",
+			"station_type_id": "72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
+			"location_x":      float64(456),
+			"location_y":      float64(123),
 		}
 
 		// Updated station type should match the one we created.

--- a/cmd/api/tests/station_tests/station_test.go
+++ b/cmd/api/tests/station_tests/station_test.go
@@ -192,8 +192,8 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 	}
 
 	{ // UPDATE
-		body := strings.NewReader(`{"name":"UPDATED stationtype0","description":"UPDATED Test description 0"}`)
-		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
+		body := strings.NewReader(`{"name":"UPDATED station0","description":"UPDATED Test description 0", "location_x":456, "location_y": 123}`)
+		url := fmt.Sprintf("/v1/station/%s", actual["id"])
 		req := httptest.NewRequest("PUT", url, body)
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
@@ -224,13 +224,15 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 			"id":           actual["id"],
 			"date_created": actual["date_created"],
 			"date_updated": updated["date_updated"],
-			"name":         "UPDATED stationtype0",
+			"name":         "UPDATED station0",
 			"description":  "UPDATED Test description 0",
+			"location_x":   float64(456),
+			"location_y":   float64(123),
 		}
 
 		// Updated station type should match the one we created.
 		if diff := cmp.Diff(want, updated); diff != "" {
-			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
+			t.Fatalf("Retrieved station should match created. Diff:\n%s", diff)
 		}
 	}
 }

--- a/cmd/api/tests/station_type_tests/station_type_test.go
+++ b/cmd/api/tests/station_type_tests/station_type_test.go
@@ -215,6 +215,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 			"date_updated": updated["date_updated"],
 			"name":         "UPDATED stationtype0",
 			"description":  "UPDATED Test description 0",
+			"stations":     float64(0),
 		}
 
 		// Updated station type should match the one we created.

--- a/cmd/api/tests/station_type_tests/station_type_test.go
+++ b/cmd/api/tests/station_type_tests/station_type_test.go
@@ -179,4 +179,47 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
 		}
 	}
+
+	{ // UPDATE
+		body := strings.NewReader(`{"name":"UPDATED stationtype0","description":"UPDATED Test description 0"}`)
+		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
+		req := httptest.NewRequest("PUT", url, body)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+
+		st.app.ServeHTTP(resp, req)
+
+		if http.StatusNoContent != resp.Code {
+			t.Fatalf("updating: expected status code %v, got %v", http.StatusNoContent, resp.Code)
+		}
+
+		// Retrieve updated record to be sure it worked.
+		req = httptest.NewRequest("GET", url, nil)
+		req.Header.Set("Content-Type", "application/json")
+		resp = httptest.NewRecorder()
+
+		st.app.ServeHTTP(resp, req)
+
+		if http.StatusOK != resp.Code {
+			t.Fatalf("retrieving: expected status code %v, got %v", http.StatusOK, resp.Code)
+		}
+
+		var updated map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+			t.Fatalf("decoding: %s", err)
+		}
+
+		want := map[string]interface{}{
+			"id":           actual["id"],
+			"date_created": actual["date_created"],
+			"date_updated": updated["date_updated"],
+			"name":         "UPDATED stationtype0",
+			"description":  "UPDATED Test description 0",
+		}
+
+		// Updated station type should match the one we created.
+		if diff := cmp.Diff(want, updated); diff != "" {
+			t.Fatalf("Retrieved station type should match created. Diff:\n%s", diff)
+		}
+	}
 }

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -12,6 +12,12 @@ import (
 // Respond converts a Go value to JSON and sends it to the client.
 func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
 
+	// In the case of Updates there will be no content to respond with
+	if statusCode == http.StatusNoContent {
+		w.WriteHeader(statusCode)
+		return nil
+	}
+
 	// Convert the response value to JSON.
 	// https://golang.org/pkg/encoding/json/#Marshal
 	res, err := json.Marshal(data)

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -41,8 +41,8 @@ func (a *App) Handle(method, url string, h Handler) {
 		if err != nil {
 
 			// Log the error.
-			// a.log.Printf("ERROR : %+v", err)
-			a.log.Println("ERROR : Validation error")
+			a.log.Printf("ERROR : %+v", err)
+			// a.log.Println("ERROR : Validation error")
 
 			// Respond to the error.
 			if err := RespondError(w, err); err != nil {

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -19,13 +19,11 @@ var migrations = []darwin.Migration{
 		Description: "Add station types",
 		Script: `
 CREATE TABLE station_type (
-	id           UUID,
+	id           UUID PRIMARY KEY,
 	name         TEXT,
 	description  TEXT,
 	date_created TIMESTAMP,
-	date_updated TIMESTAMP,
-
-	PRIMARY KEY (id)
+	date_updated TIMESTAMP
 );`,
 	},
 	{
@@ -33,7 +31,7 @@ CREATE TABLE station_type (
 		Description: "Add station",
 		Script: `
 CREATE TABLE station (
-	id              UUID,
+	id              UUID PRIMARY KEY,
 	station_type_id UUID,
 	name            TEXT,
 	description     TEXT,
@@ -42,8 +40,10 @@ CREATE TABLE station (
 	date_created    TIMESTAMP,
 	date_updated    TIMESTAMP,
 
-	PRIMARY KEY (id),
-	FOREIGN KEY (station_type_id) REFERENCES station_type(id) ON DELETE CASCADE
+	CONSTRAINT fk_station_type_id
+		FOREIGN KEY (station_type_id)
+		REFERENCES station_type(id)
+		ON DELETE CASCADE
 );`,
 	},
 }

--- a/internal/station_type/models.go
+++ b/internal/station_type/models.go
@@ -29,6 +29,17 @@ type NewStationType struct {
 	Description string    `json:"description"`
 }
 
+// UpdateStationType defines what information may be provided to modify an
+// existing StationType. All fields are optional so clients can send just the
+// fields they want changed. It uses pointer fields so we can differentiate
+// between a field that were not provided and a field that was provided as
+// explicitly blank. Normally we do not want to use pointers to basic types but
+// we make exceptions around marshalling/unmarshalling.
+type UpdateStationType struct {
+	Name         *string `json:"name"`
+	Description  *string `json:"description"`
+}
+
 // Station is a station that is defined as one of the station types in StationType.
 type Station struct {
 	Id            string    `db:"id"              json:"id"`
@@ -47,4 +58,17 @@ type NewStation struct {
 	Description   string    `db:"description"     json:"description"`
 	LocationX     int       `db:"location_x"      json:"location_x" validate:"required,gte=0"`
 	LocationY     int       `db:"location_y"      json:"location_y" validate:"required,gte=0"`
+}
+
+// UpdateStation defines what information may be provided to modify an
+// existing Station. All fields are optional so clients can send just the
+// fields they want changed. It uses pointer fields so we can differentiate
+// between a field that were not provided and a field that was provided as
+// explicitly blank. Normally we do not want to use pointers to basic types but
+// we make exceptions around marshalling/unmarshalling.
+type UpdateStation struct {
+	Name         *string `json:"name"`
+	Description  *string `json:"description"`
+	LocationX    *int    `json:"location_x" validate:"omitempty,gte=0"`
+	LocationY    *int    `json:"location_y" validate:"omitempty,gte=0"`
 }

--- a/internal/station_type/models.go
+++ b/internal/station_type/models.go
@@ -52,7 +52,7 @@ type Station struct {
 	DateUpdated   time.Time `db:"date_updated"    json:"date_updated"`
 }
 
-// NewStation is a what we require from clients when adding a BaseStation.
+// NewStation is a what we require from clients when adding a Station.
 type NewStation struct {
 	Name          string    `db:"name"            json:"name" validate:"required"`
 	Description   string    `db:"description"     json:"description"`

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -89,6 +89,22 @@ func AdjustStation(ctx context.Context, db *sqlx.DB, id string, update UpdateSta
 	return nil
 }
 
+// DeleteStation removes the station identified by a given ID.
+func DeleteStation(ctx context.Context, db *sqlx.DB, id string) error {
+	// Validate id is a valid uuid
+	if _, err := uuid.Parse(id); err != nil {
+		return ErrInvalidID
+	}
+
+	const q = `DELETE FROM station WHERE id = $1`
+
+	if _, err := db.ExecContext(ctx, q, id); err != nil {
+		return errors.Wrapf(err, "deleting station %s", id)
+	}
+
+	return nil
+}
+
 // ListStations gives all Stations for a StationType.
 func ListStations(ctx context.Context, db *sqlx.DB, stationTypeID string) ([]Station, error) {
 	stations := []Station{}

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -124,6 +124,8 @@ func RetrieveStation(ctx context.Context, db *sqlx.DB, id string) (*Station, err
 		    station_type_id,
 			name,
 			description,
+			location_x,
+			location_y,
 			date_created,
 			date_updated
 		FROM station

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -151,7 +151,7 @@ func RetrieveStation(ctx context.Context, db *sqlx.DB, id string) (*Station, err
 
 	if err := db.GetContext(ctx, &s, q, id); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, ErrNotFound
+			return nil, ErrStationNotFound
 		}
 
 		return nil, errors.Wrap(err, "selecting single station")

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -3,6 +3,7 @@ package station_type
 import (
 	// Core packages
 	"context"
+	"database/sql"
 	"time"
 
 	// Third-party packages
@@ -45,6 +46,47 @@ func AddStation(ctx context.Context, db *sqlx.DB, ns NewStation, stationTypeID s
 	return &s, nil
 }
 
+// AdjustStation modifies data about a Station. It will error if the specified ID is
+// invalid or does not reference an existing Station.
+func AdjustStation(ctx context.Context, db *sqlx.DB, id string, update UpdateStation, now time.Time) error {
+	s, err := RetrieveStation(ctx, db, id)
+	if err != nil {
+		return err
+	}
+
+	if update.Name != nil {
+		s.Name = *update.Name
+	}
+	if update.Description != nil {
+		s.Description = *update.Description
+	}
+	if update.LocationX != nil {
+		s.LocationX = *update.LocationX
+	}
+	if update.LocationY != nil {
+		s.LocationY = *update.LocationY
+	}
+	s.DateUpdated = now
+
+	const q = `UPDATE station SET
+		"name" = $2,
+		"description" = $3,
+        "location_x" = $4,
+        "location_x" = $5,
+		WHERE id = $1`
+	_, err = db.ExecContext(ctx, q, id,
+		s.Name,
+		s.Description,
+		s.LocationX,
+		s.LocationY,
+	)
+	if err != nil {
+		return errors.Wrap(err, "updating station")
+	}
+
+	return nil
+}
+
 // ListStations gives all Stations for a StationType.
 func ListStations(ctx context.Context, db *sqlx.DB, stationTypeID string) ([]Station, error) {
 	stations := []Station{}
@@ -66,4 +108,34 @@ func ListStations(ctx context.Context, db *sqlx.DB, stationTypeID string) ([]Sta
 	}
 
 	return stations, nil
+}
+
+// Retrieve gets a specific Station from the database.
+func RetrieveStation(ctx context.Context, db *sqlx.DB, id string) (*Station, error) {
+	if _, err := uuid.Parse(id); err != nil {
+		return nil, ErrInvalidID
+	}
+
+	var s Station
+
+	const q = `
+		SELECT
+			id,
+		    station_type_id,
+			name,
+			description,
+			date_created,
+			date_updated
+		FROM station
+		WHERE id = $1`
+
+	if err := db.GetContext(ctx, &s, q, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
+
+		return nil, errors.Wrap(err, "selecting single station")
+	}
+
+	return &s, nil
 }

--- a/internal/station_type/station.go
+++ b/internal/station_type/station.go
@@ -21,8 +21,8 @@ func AddStation(ctx context.Context, db *sqlx.DB, ns NewStation, stationTypeID s
 		Description:   ns.Description,
 		LocationX:     ns.LocationX,
 		LocationY:     ns.LocationY,
-		DateCreated:   now,
-		DateUpdated:   now,
+		DateCreated:   now.UTC(),
+		DateUpdated:   now.UTC(),
 	}
 
 	const q = `INSERT INTO station
@@ -72,13 +72,15 @@ func AdjustStation(ctx context.Context, db *sqlx.DB, id string, update UpdateSta
 		"name" = $2,
 		"description" = $3,
         "location_x" = $4,
-        "location_x" = $5,
+        "location_y" = $5,
+        "date_updated" = $6
 		WHERE id = $1`
 	_, err = db.ExecContext(ctx, q, id,
 		s.Name,
 		s.Description,
 		s.LocationX,
 		s.LocationY,
+		s.DateUpdated,
 	)
 	if err != nil {
 		return errors.Wrap(err, "updating station")

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -125,7 +125,7 @@ func Update(ctx context.Context, db *sqlx.DB, id string, update UpdateStationTyp
 
 	const q = `UPDATE station_type SET
 		"name" = $2,
-		"description" = $3,
+		"description" = $3
 		WHERE id = $1`
 	_, err = db.ExecContext(ctx, q, id,
 		st.Name,

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -75,7 +75,7 @@ func List(ctx context.Context, db *sqlx.DB) ([]StationType, error) {
 	return station_type, nil
 }
 
-// Retrieve gets a specific StationType from the database.
+// Retrieve gets a specific StationType and all the stations of that type from the database.
 func Retrieve(ctx context.Context, db *sqlx.DB, id string) (*StationType, error) {
 	if _, err := uuid.Parse(id); err != nil {
 		return nil, ErrInvalidID
@@ -125,11 +125,13 @@ func Update(ctx context.Context, db *sqlx.DB, id string, update UpdateStationTyp
 
 	const q = `UPDATE station_type SET
 		"name" = $2,
-		"description" = $3
+		"description" = $3,
+		"date_updated" = $4
 		WHERE id = $1`
 	_, err = db.ExecContext(ctx, q, id,
 		st.Name,
 		st.Description,
+		st.DateUpdated,
 	)
 	if err != nil {
 		return errors.Wrap(err, "updating station tyoe")

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -17,6 +17,9 @@ var (
 	// ErrNotFound is used when a specific StationType is requested but does not exist.
 	ErrNotFound = errors.New("station type not found")
 
+	// ErrStationNotFound is used when a specific Station is requested but does not exist.
+	ErrStationNotFound = errors.New("station not found")
+
 	// ErrInvalidID is used when an invalid UUID is provided.
 	ErrInvalidID = errors.New("ID is not in its proper UUID format")
 )
@@ -59,7 +62,7 @@ func Delete(ctx context.Context, db *sqlx.DB, id string) error {
 		return ErrInvalidID
 	}
 
-	const q = `DELETE FROM station_types WHERE id = $1`
+	const q = `DELETE FROM station_type WHERE id = $1`
 
 	if _, err := db.ExecContext(ctx, q, id); err != nil {
 		return errors.Wrapf(err, "deleting station type %s", id)

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -52,6 +52,22 @@ func Create(ctx context.Context, db *sqlx.DB, nst NewStationType, now time.Time)
 	return &st, nil
 }
 
+// Delete removes the station type identified by a given ID.
+func Delete(ctx context.Context, db *sqlx.DB, id string) error {
+	// Validate id is a valid uuid
+	if _, err := uuid.Parse(id); err != nil {
+		return ErrInvalidID
+	}
+
+	const q = `DELETE FROM station_types WHERE id = $1`
+
+	if _, err := db.ExecContext(ctx, q, id); err != nil {
+		return errors.Wrapf(err, "deleting station type %s", id)
+	}
+
+	return nil
+}
+
 // List gets all StationType from the database.
 func List(ctx context.Context, db *sqlx.DB) ([]StationType, error) {
 	station_type := []StationType{}

--- a/internal/station_type/station_type.go
+++ b/internal/station_type/station_type.go
@@ -106,3 +106,34 @@ func Retrieve(ctx context.Context, db *sqlx.DB, id string) (*StationType, error)
 
 	return &st, nil
 }
+
+// Update modifies data about a StationType. It will error if the specified ID is
+// invalid or does not reference an existing StationType.
+func Update(ctx context.Context, db *sqlx.DB, id string, update UpdateStationType, now time.Time) error {
+	st, err := Retrieve(ctx, db, id)
+	if err != nil {
+		return err
+	}
+
+	if update.Name != nil {
+		st.Name = *update.Name
+	}
+	if update.Description != nil {
+		st.Description = *update.Description
+	}
+	st.DateUpdated = now
+
+	const q = `UPDATE station_type SET
+		"name" = $2,
+		"description" = $3,
+		WHERE id = $1`
+	_, err = db.ExecContext(ctx, q, id,
+		st.Name,
+		st.Description,
+	)
+	if err != nil {
+		return errors.Wrap(err, "updating station tyoe")
+	}
+
+	return nil
+}

--- a/internal/station_type/station_type_test.go
+++ b/internal/station_type/station_type_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestStationTypeCreateRetrieve(t *testing.T) {
+func TestStationType(t *testing.T) {
 	db, teardown := tests.NewUnit(t)
 	defer teardown()
 
@@ -38,6 +38,32 @@ func TestStationTypeCreateRetrieve(t *testing.T) {
 
 	if diff := cmp.Diff(st1, st0); diff != "" {
 		t.Fatalf("fetched != created:\n%s", diff)
+	}
+
+	update := station_type.UpdateStationType{
+		Name: tests.StringPointer("Station Type 0"),
+		Description: tests.StringPointer("Station type description 0"),
+	}
+	updatedTime := time.Date(2019, time.January, 1, 1, 1, 1, 0, time.UTC)
+
+	if err := station_type.Update(ctx, db, st0.Id, update, updatedTime); err != nil {
+		t.Fatalf("updating station type st0: %s", err)
+	}
+
+	saved, err := station_type.Retrieve(ctx, db, st0.Id)
+	if err != nil {
+		t.Fatalf("getting station type st0: %s", err)
+	}
+
+	// Check specified fields were updated. Make a copy of the original product
+	// and change just the fields we expect then diff it with what was saved.
+	want := *st0
+	want.Name = "Station Type 0"
+	want.Description = "Station type description 0"
+	want.DateUpdated = updatedTime
+
+	if diff := cmp.Diff(want, *saved); diff != "" {
+		t.Fatalf("updated record did not match:\n%s", diff)
 	}
 }
 

--- a/internal/tests/test.go
+++ b/internal/tests/test.go
@@ -73,3 +73,17 @@ func NewUnit(t *testing.T) (*sqlx.DB, func()) {
 
 	return db, teardown
 }
+
+// StringPointer is a helper to get a *string from a string. It is in the tests
+// package because we normally don't want to deal with pointers to basic types
+// but it's useful in some tests.
+func StringPointer(s string) *string {
+	return &s
+}
+
+// IntPointer is a helper to get a *int from a int. It is in the tests package
+// because we normally don't want to deal with pointers to basic types but it's
+// useful in some tests.
+func IntPointer(i int) *int {
+	return &i
+}

--- a/resources/postman_collection.json
+++ b/resources/postman_collection.json
@@ -16,8 +16,7 @@
 							"var jsonData = JSON.parse(responseBody);",
 							"postman.setEnvironmentVariable(\"Token\", jsonData.token);",
 							""
-						],
-						"id": "c45fe2f3-fdd9-435a-92a4-7fedf284323b"
+						]
 					}
 				}
 			],
@@ -186,21 +185,21 @@
 					"raw": "{\n\t\"name\": \"New New Test Station Type\"\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station-type/d1add113-a33f-4c05-8d08-002b7adf8c0b",
+					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station-type",
-						"d1add113-a33f-4c05-8d08-002b7adf8c0b"
+						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
 					]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "Delete WaterStation Station Type",
+			"name": "Delete Station Type",
 			"request": {
 				"auth": {
 					"type": "bearer",
@@ -274,14 +273,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+					"raw": "{{SERVER}}/v1/station/f676f266-590c-11eb-ae93-0242ac130002",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station",
-						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
+						"f676f266-590c-11eb-ae93-0242ac130002"
 					]
 				}
 			},
@@ -309,17 +308,17 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"Test station\",\n\t\"description\": \"Test station decription two\",\n    \"location_x\": 4,\n    \"location_y\": 5\n}"
+					"raw": "{\n\t\"name\": \"Test Station\",\n\t\"description\": \"Test station decription\",\n    \"location_x\": 9,\n    \"location_y\": 9\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station-type/72f8b983-3eb4-48db-9ed0-e45cc6bd716b/station",
+					"raw": "{{SERVER}}/v1/station-type/39fc9b9b-4584-4c01-9911-8b010b5d72b8/station",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station-type",
-						"72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
+						"39fc9b9b-4584-4c01-9911-8b010b5d72b8",
 						"station"
 					]
 				}
@@ -348,17 +347,17 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"New New Test Station Type\"\n}"
+					"raw": "{\n\t\"name\": \"New New Test Station\"\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station/d1add113-a33f-4c05-8d08-002b7adf8c0b",
+					"raw": "{{SERVER}}/v1/station/f676f266-590c-11eb-ae93-0242ac130002",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station",
-						"d1add113-a33f-4c05-8d08-002b7adf8c0b"
+						"f676f266-590c-11eb-ae93-0242ac130002"
 					]
 				}
 			},
@@ -416,7 +415,6 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "9eba4917-9948-4209-9e33-c39e376d1bb5",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -426,13 +424,11 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "cef76e2b-f3c0-463a-a11c-593fcba7dab5",
 				"type": "text/javascript",
 				"exec": [
 					""
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/resources/postman_collection.json
+++ b/resources/postman_collection.json
@@ -91,7 +91,7 @@
 			"response": []
 		},
 		{
-			"name": "Get Station Types",
+			"name": "Get Station Type",
 			"request": {
 				"auth": {
 					"type": "bearer",
@@ -106,14 +106,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station-type/fc935253-83af-47e7-a7c8-9f9ee182b34e",
+					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station-type",
-						"fc935253-83af-47e7-a7c8-9f9ee182b34e"
+						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
 					]
 				}
 			},
@@ -141,7 +141,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": \"Test name3\",\n    \"description\": \"Test description3\"\n}",
+					"raw": "{\n    \"name\": \"Test Station Tyoe\",\n    \"description\": \"Test station tyoe description\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -183,17 +183,17 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"New Test Station\"\n}"
+					"raw": "{\n\t\"name\": \"New New Test Station Type\"\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+					"raw": "{{SERVER}}/v1/station-type/d1add113-a33f-4c05-8d08-002b7adf8c0b",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station-type",
-						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
+						"d1add113-a33f-4c05-8d08-002b7adf8c0b"
 					]
 				}
 			},
@@ -244,14 +244,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{SERVER}}/v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e/stations",
+					"raw": "{{SERVER}}/v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/stations",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
 						"station-type",
-						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+						"5c86bbaa-4ef8-11eb-ae93-0242ac130002",
 						"stations"
 					]
 				}
@@ -280,18 +280,56 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"quantity\": 2,\n\t\"paid\": 40\n}"
+					"raw": "{\n\t\"name\": \"Test station\",\n\t\"description\": \"Test station decription two\",\n    \"location_x\": 4,\n    \"location_y\": 5\n}"
 				},
 				"url": {
-					"raw": "{{SERVER}}/v1/stations-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e/station",
+					"raw": "{{SERVER}}/v1/station-type/72f8b983-3eb4-48db-9ed0-e45cc6bd716b/station",
 					"host": [
 						"{{SERVER}}"
 					],
 					"path": [
 						"v1",
-						"stations-type",
-						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+						"station-type",
+						"72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
 						"station"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update Station",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"name\": \"New New Test Station Type\"\n}"
+				},
+				"url": {
+					"raw": "{{SERVER}}/v1/station/d1add113-a33f-4c05-8d08-002b7adf8c0b",
+					"host": [
+						"{{SERVER}}"
+					],
+					"path": [
+						"v1",
+						"station",
+						"d1add113-a33f-4c05-8d08-002b7adf8c0b"
 					]
 				}
 			},

--- a/resources/postman_collection.json
+++ b/resources/postman_collection.json
@@ -259,6 +259,35 @@
 			"response": []
 		},
 		{
+			"name": "Get Station",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{SERVER}}/v1/station/a2b0639f-2cc6-44b8-b97b-15d69dbb511e",
+					"host": [
+						"{{SERVER}}"
+					],
+					"path": [
+						"v1",
+						"station",
+						"a2b0639f-2cc6-44b8-b97b-15d69dbb511e"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Add Station",
 			"request": {
 				"auth": {
@@ -330,6 +359,35 @@
 						"v1",
 						"station",
 						"d1add113-a33f-4c05-8d08-002b7adf8c0b"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete Station",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{SERVER}}/v1/station/72f8b983-3eb4-48db-9ed0-e45cc6bd716b",
+					"host": [
+						"{{SERVER}}"
+					],
+					"path": [
+						"v1",
+						"station",
+						"72f8b983-3eb4-48db-9ed0-e45cc6bd716b"
 					]
 				}
 			},


### PR DESCRIPTION
resolves #37           

### Description

This PR adds `UPDATE` endpoints:
- `PUT /v1/station-type/{station-type-id}`
- `PUT /v1/station/{station-id}`

As well as supporting endpoint:
- `GET /v1/station/{station-id}

And adds `DELETE` endpoints:
- `DELETE /v1/station-type/{station-type-id}`
- `DELETE /v1/station/{station-id}`

### How to Test

- [ ] confirm existing endpoints continue to work
- [ ] confirm update endpoints can alter the values of existing records
- [ ] confirm the that existing records can be deleted
- [ ] confirm the `DELETE /v1/station-type/{station-type-id}` endpoint does not allow deletion when stations of that type exist