### PR TITLE
Issue 40 GET /v1/health

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ Seeding complete
 
 - **Unit Tests**
 
+**station_type** and **station**
 ```
 > go test ./internal/station_type
-ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	6.805s
+ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	13.515s
 ```
 
 NOTE: test coverage reports:
@@ -103,6 +104,9 @@ alais gotwc='go test -coverprofile=coverage.out && go tool cover -html=coverage.
 # bust cache
 > go clean -testcache
 
-> go test ./cmd/api/tests
-ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests. 6.373s
+> go test ./cmd/api/tests/station_tests
+ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_tests	3.248s
+
+> go test ./cmd/api/tests/station_type_tests
+ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_type_tests	2.875s
 ```

--- a/cmd/api/internal/handlers/check.go
+++ b/cmd/api/internal/handlers/check.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	// Core packages
+	"net/http"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database"
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
+
+	// Third-party packages
+	"github.com/jmoiron/sqlx"
+)
+
+// Check provides support for orchestration health checks.
+type Check struct {
+	db *sqlx.DB
+}
+
+// Health validates the service is healthy and ready to accept requests.
+func (c *Check) Health(w http.ResponseWriter, r *http.Request) error {
+
+	var health struct {
+		Status string `json:"status"`
+	}
+
+	// Check if the database is ready.
+	if err := database.StatusCheck(r.Context(), c.db); err != nil {
+
+		// If the database is not ready we will tell the client and use a 500
+		// status. Do not respond by just returning an error because further up in
+		// the call stack will interpret that as an unhandled error.
+		health.Status = "db not ready"
+		return web.Respond(w, health, http.StatusInternalServerError)
+	}
+
+	health.Status = "ok"
+	return web.Respond(w, health, http.StatusOK)
+}
+

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -17,19 +17,27 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 
 	app := web.NewApp(log)
 
-	st := StationType{db: db, log: log}
+	{
+		c := Check{db: db}
 
-	app.Handle(http.MethodGet,    "/v1/station-types", st.List)
-	app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve)
-	app.Handle(http.MethodPost,   "/v1/station-type", st.Create)
-	app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update)
-	app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete)
+		app.Handle(http.MethodGet, "/v1/health", c.Health)
+	}
 
-	app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations)
-	app.Handle(http.MethodGet,    "/v1/station/{id}", st.RetrieveStation)
-	app.Handle(http.MethodPost,   "/v1/station-type/{id}/station", st.AddStation)
-	app.Handle(http.MethodPut,    "/v1/station/{id}", st.AdjustStation)
-	app.Handle(http.MethodDelete, "/v1/station/{id}", st.DeleteStation)
+	{
+		st := StationType{db: db, log: log}
+
+		app.Handle(http.MethodGet,    "/v1/station-types",     st.List)
+		app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve)
+		app.Handle(http.MethodPost,   "/v1/station-type",      st.Create)
+		app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update)
+		app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete)
+
+		app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations)
+		app.Handle(http.MethodGet,    "/v1/station/{id}",               st.RetrieveStation)
+		app.Handle(http.MethodPost,   "/v1/station-type/{id}/station",  st.AddStation)
+		app.Handle(http.MethodPut,    "/v1/station/{id}",               st.AdjustStation)
+		app.Handle(http.MethodDelete, "/v1/station/{id}",               st.DeleteStation)
+	}
 
 	return app
 }

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -53,6 +53,11 @@ func Open(cfg Config) (*sqlx.DB, error) {
 // returns a non-nil error otherwise.
 func StatusCheck(ctx context.Context, db *sqlx.DB) error {
 
+	// Confirm connection to database exists, could be cached
+	if err := db.Ping();err != nil {
+		return err
+	}
+
 	// Run a simple query to determine connectivity. The db has a "Ping" method
 	// but it can false-positive when it was previously able to talk to the
 	// database but the database has since gone away. Running this query forces a

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"net/url"
 
 	// Third-party packages
@@ -46,4 +47,17 @@ func Open(cfg Config) (*sqlx.DB, error) {
 	}
 
 	return sqlx.Open("postgres", u.String())
+}
+
+// StatusCheck returns nil if it can successfully talk to the database. It
+// returns a non-nil error otherwise.
+func StatusCheck(ctx context.Context, db *sqlx.DB) error {
+
+	// Run a simple query to determine connectivity. The db has a "Ping" method
+	// but it can false-positive when it was previously able to talk to the
+	// database but the database has since gone away. Running this query forces a
+	// round trip to the database.
+	const q = `SELECT true`
+	var tmp bool
+	return db.QueryRowContext(ctx, q).Scan(&tmp)
 }

--- a/internal/station_type/station_type_test.go
+++ b/internal/station_type/station_type_test.go
@@ -31,6 +31,12 @@ func TestStationType(t *testing.T) {
 		t.Fatalf("creating station type st0: %s", err)
 	}
 
+	// Invalid uuid
+	_, err = station_type.Retrieve(ctx, db, "abc123")
+	if err == nil {
+		t.Fatalf("getting invalid uuid station type abc123: %s", err)
+	}
+
 	st1, err := station_type.Retrieve(ctx, db, st0.Id)
 	if err != nil {
 		t.Fatalf("getting station type p0: %s", err)
@@ -45,6 +51,11 @@ func TestStationType(t *testing.T) {
 		Description: tests.StringPointer("Station type description 0"),
 	}
 	updatedTime := time.Date(2019, time.January, 1, 1, 1, 1, 0, time.UTC)
+
+	// Invalid uuid
+	if err := station_type.Update(ctx, db, "abc123", update, updatedTime); err == nil {
+		t.Fatalf("updating station type invalid uuid abc123: %s", err)
+	}
 
 	if err := station_type.Update(ctx, db, st0.Id, update, updatedTime); err != nil {
 		t.Fatalf("updating station type st0: %s", err)
@@ -64,6 +75,24 @@ func TestStationType(t *testing.T) {
 
 	if diff := cmp.Diff(want, *saved); diff != "" {
 		t.Fatalf("updated record did not match:\n%s", diff)
+	}
+
+	// Delete invalid Station Type, should not return error
+	err = station_type.Delete(ctx, db, "123456")
+	if err == nil {
+		t.Fatalf("delete invalid uuid station type should have not failed: %s", err)
+	}
+
+	// Delete invalid Station Type, should not return error
+	err = station_type.Delete(ctx, db, st0.Id)
+	if err != nil {
+		t.Fatalf("delete station type should have not failed: %s", err)
+	}
+
+	// Attempt to retrieve deleted station type
+	_, err = station_type.Retrieve(ctx, db, st0.Id)
+	if err == nil {
+		t.Fatalf("getting deleted station type st0: %s", err)
 	}
 }
 


### PR DESCRIPTION
resolves #40            

### Description

This PR adds health endpoint:
- `GET /v1/health`

### How to Test

- [ ] start / stop database: `docker-compose down / up`
- [ ] depending on the state of the database, confirm the response to `GET /v1/health`

**Response**: 500
```
{
    "status": "db not ready"
}
```

**Response**: 200
```
{
    "status": "ok"
}
```