### PR TITLE
Issue-42 Add profiling using net/http/pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ courses at **[Ardan Labs](https://education.ardanlabs.com/collections?category=c
   - `GET  /v1/station-types`
   - `GET  /v1/station-type/{id}`
   - `POST /v1/station-type`
+  - `DELETE /v1/station-type/{id}`
   - `GET  /v1/station-type/{station-type-id}/stations`
   - `POST /v1/station-type/{station-type-id}/station`
+  - `DELETE /v1/station/{id}`
 
 #### Admin tools
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof" // Register the pprof handlers
 	"os"
 	"os/signal"
 	"syscall"
@@ -51,6 +52,7 @@ func run() error {
 	var cfg struct {
 		Web struct {
 			Address         string        `conf:"default:localhost:8000"`
+			Debug           string        `conf:"default:localhost:6060"`
 			ReadTimeout     time.Duration `conf:"default:5s"`
 			WriteTimeout    time.Duration `conf:"default:5s"`
 			ShutdownTimeout time.Duration `conf:"default:5s"`
@@ -102,6 +104,20 @@ func run() error {
 		return errors.Wrap(err, "connecting to db")
 	}
 	defer db.Close()
+
+	// =========================================================================
+	// Start Debug Service
+
+	/**
+	 * GET /debug/pprof - Added to the default mux by importing the net/http/pprof package.
+	 *
+	 * Not concerned with shutting this down when the application is shutdown.
+	 */
+	go func() {
+		log.Println("debug service listening on", cfg.Web.Debug)
+		err := http.ListenAndServe(cfg.Web.Debug, http.DefaultServeMux)
+		log.Println("debug service closed", err)
+	}()
 
 	// =========================================================================
 	// Start API Service

--- a/resources/postman_collection.json
+++ b/resources/postman_collection.json
@@ -409,6 +409,25 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Profiling",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{SERVER-PROFILE}}/debug/pprof/",
+					"host": [
+						"{{SERVER-PROFILE}}"
+					],
+					"path": [
+						"debug",
+						"pprof",
+						""
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"event": [

--- a/resources/postman_environment.json
+++ b/resources/postman_environment.json
@@ -11,9 +11,14 @@
 			"key": "SERVER",
 			"value": "http://localhost:8000",
 			"enabled": true
+		},
+		{
+			"key": "SERVER-PROFILE",
+			"value": "http://localhost::6060",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2021-01-10T21:57:58.054Z",
-	"_postman_exported_using": "Postman/7.34.0"
+	"_postman_exported_at": "2021-01-24T22:14:25.171Z",
+	"_postman_exported_using": "Postman/7.36.1"
 }


### PR DESCRIPTION
resolves #42             

### Description

This PR adds  endpoint:
- `GET http://localhost:6060/debug/pprof/`

### How to Test

- [x] confirm when starting api server the `pprof` port is running
```
> go run ./cmd/api
STATIONS : 2021/01/24 17:37:54.484986 main.go:84: main : Started
STATIONS : 2021/01/24 17:37:54.485162 main.go:91: main : Config :
--web-address=localhost:8000
--web-debug=localhost:6060
--web-read-timeout=5s
--web-write-timeout=5s
--web-shutdown-timeout=5s
--db-user=postgres
--db-host=localhost
--db-name=postgres
--db-disable-tls=true
STATIONS : 2021/01/24 17:37:54.485333 main.go:152: main : API listening on localhost:8000
STATIONS : 2021/01/24 17:37:54.485363 main.go:117: debug service listening on localhost:6060
```

- [x] confirm in browser that `http://localhost:6060/debug/pprof/` returns the `pprof` dashboard
![image](https://user-images.githubusercontent.com/2119264/105646016-6a212200-5e6b-11eb-9445-23b0d79f27dd.png)

- [x] test running cpu profiling
  - run load test:
```
> hey -c 10 -n 1015000 http://localhost:8000/v1/products
```
  - run `pprof`:
```
> go tool pprof http://localhost:6060/debug/pprof/profile\?seconds\=8
```

- [x] `(pprof) top` to see which functions are taking the most time
![image](https://user-images.githubusercontent.com/2119264/105646747-99d22900-5e6f-11eb-9348-b0514cb985aa.png)

- [x] `(pprof) top -cum` to see a cumulative total for function run time
![image](https://user-images.githubusercontent.com/2119264/105646796-e584d280-5e6f-11eb-97db-91e1e75d545c.png)

- [x] `(pprof) web` to see a call graph
![image](https://user-images.githubusercontent.com/2119264/105647987-1caab200-5e77-11eb-99bb-164959f0b19f.png)


Resources:
- [Profiling Go programs with pprof](https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/)
- [Package pprof](https://golang.org/pkg/net/http/pprof/)
- [rakyll/hey - load generator](https://github.com/rakyll/hey#usage)
- [graphviz](https://www.graphviz.org/) - `brew install graphviz`
