### PR TITLE
Issue-48 log request details as middleware

### DIFF
--- a/cmd/api/internal/handlers/check.go
+++ b/cmd/api/internal/handlers/check.go
@@ -31,10 +31,9 @@ func (c *Check) Health(w http.ResponseWriter, r *http.Request) error {
 		// status. Do not respond by just returning an error because further up in
 		// the call stack will interpret that as an unhandled error.
 		health.Status = "db not ready"
-		return web.Respond(w, health, http.StatusInternalServerError)
+		return web.Respond(r.Context(), w, health, http.StatusInternalServerError)
 	}
 
 	health.Status = "ok"
-	return web.Respond(w, health, http.StatusOK)
+	return web.Respond(r.Context(), w, health, http.StatusOK)
 }
-

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -17,7 +17,7 @@ import (
 func API(db *sqlx.DB, log *log.Logger) http.Handler {
 
 	// Construct the web.App which holds all routes as well as common Middleware.
-	app := web.NewApp(log, mid.Errors(log), mid.Metrics())
+	app := web.NewApp(log, mid.Logger(log), mid.Errors(log), mid.Metrics())
 
 	{
 		c := Check{db: db}

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -36,7 +36,7 @@ func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "creating new station type")
 	}
 
-	return web.Respond(w, &stationType, http.StatusCreated)
+	return web.Respond(r.Context(), w, &stationType, http.StatusCreated)
 }
 
 // Delete removes a single station type identified by an ID in the request URL.
@@ -52,7 +52,7 @@ func (p *StationType) Delete(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(w, nil, http.StatusNoContent)
+	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
 }
 
 /**
@@ -72,7 +72,7 @@ func (st *StationType) List(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "getting station type list")
 	}
 
-	return web.Respond(w, list, http.StatusOK)
+	return web.Respond(r.Context(), w, list, http.StatusOK)
 }
 
 // Retrieve finds all stations of a station type identified by a station type ID in the request URL.
@@ -91,7 +91,7 @@ func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(w, stationTypes, http.StatusOK)
+	return web.Respond(r.Context(), w, stationTypes, http.StatusOK)
 }
 
 // Update decodes the body of a request to update an existing station type. The ID
@@ -115,7 +115,7 @@ func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(w, nil, http.StatusNoContent)
+	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
 }
 
 /**
@@ -137,7 +137,7 @@ func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error 
 		return errors.Wrap(err, "adding new sale")
 	}
 
-	return web.Respond(w, station, http.StatusCreated)
+	return web.Respond(r.Context(), w, station, http.StatusCreated)
 }
 
 // Delete removes a single station identified by an ID in the request URL.
@@ -153,7 +153,7 @@ func (p *StationType) DeleteStation(w http.ResponseWriter, r *http.Request) erro
 		}
 	}
 
-	return web.Respond(w, nil, http.StatusNoContent)
+	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
 }
 
 // ListStations gets all sales for a particular station type.
@@ -165,7 +165,7 @@ func (st *StationType) ListStations(w http.ResponseWriter, r *http.Request) erro
 		return errors.Wrap(err, "getting sales list")
 	}
 
-	return web.Respond(w, list, http.StatusOK)
+	return web.Respond(r.Context(), w, list, http.StatusOK)
 }
 
 // Retrieve finds a single station identified by an ID in the request URL.
@@ -184,7 +184,7 @@ func (st *StationType) RetrieveStation(w http.ResponseWriter, r *http.Request) e
 		}
 	}
 
-	return web.Respond(w, station, http.StatusOK)
+	return web.Respond(r.Context(), w, station, http.StatusOK)
 }
 
 // Update decodes the body of a request to update an existing station. The ID
@@ -208,5 +208,5 @@ func (st *StationType) AdjustStation(w http.ResponseWriter, r *http.Request) err
 		}
 	}
 
-	return web.Respond(w, nil, http.StatusNoContent)
+	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
 }

--- a/internal/mid/errors.go
+++ b/internal/mid/errors.go
@@ -26,7 +26,7 @@ func Errors(log *log.Logger) web.Middleware {
 				log.Printf("ERROR : %+v", err)
 
 				// Respond to the error.
-				if err := web.RespondError(w, err); err != nil {
+				if err := web.RespondError(r.Context(), w, err); err != nil {
 					return err
 				}
 			}

--- a/internal/mid/logger.go
+++ b/internal/mid/logger.go
@@ -1,0 +1,44 @@
+package mid
+
+import (
+	// Core packages
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
+)
+
+// Logger writes some information about the request to the logs in the
+// format: (200) GET /foo -> IP ADDR (latency)
+func Logger(log *log.Logger) web.Middleware {
+
+	// This is the actual middleware function to be executed.
+	f := func(before web.Handler) web.Handler {
+
+		// Create the handler that will be attached in the middleware chain.
+		h := func(w http.ResponseWriter, r *http.Request) error {
+			v, ok := r.Context().Value(web.KeyValues).(*web.Values)
+			if !ok {
+				return errors.New("web value missing from context")
+			}
+
+			err := before(w, r)
+
+			log.Printf("(%d) : %s %s -> %s (%s)",
+				v.StatusCode,
+				r.Method, r.URL.Path,
+				r.RemoteAddr, time.Since(v.Start),
+			)
+
+			// Return the error so it can be handled further up the chain.
+			return err
+		}
+
+		return h
+	}
+
+	return f
+}

--- a/internal/mid/logger.go
+++ b/internal/mid/logger.go
@@ -27,9 +27,11 @@ func Logger(log *log.Logger) web.Middleware {
 
 			err := before(w, r)
 
-			log.Printf("(%d) : %s %s -> %s (%s)",
-				v.StatusCode,
-				r.Method, r.URL.Path,
+			// Format log message
+			// ex: POST (201) : /v1/station-type -> 127.0.0.1:53670 (6.408225ms)
+			log.Printf("%s (%d) : %s -> %s (%s)",
+				r.Method, v.StatusCode,
+				r.URL.Path,
 				r.RemoteAddr, time.Since(v.Start),
 			)
 

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -2,15 +2,20 @@ package web
 
 import (
 	// Core packages
+	"context"
 	"encoding/json"
 	"net/http"
 
-	// Third party packages
+	// Third-party packages
 	"github.com/pkg/errors"
 )
 
 // Respond converts a Go value to JSON and sends it to the client.
-func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
+func Respond(ctx context.Context, w http.ResponseWriter, data interface{}, statusCode int) error {
+
+	// Set the status code for the request logger middleware.
+	v := ctx.Value(KeyValues).(*Values)
+	v.StatusCode = statusCode
 
 	// In the case of Updates there will be no content to respond with
 	if statusCode == http.StatusNoContent {
@@ -37,7 +42,7 @@ func Respond(w http.ResponseWriter, data interface{}, statusCode int) error {
 }
 
 // RespondError sends an error reponse back to the client.
-func RespondError(w http.ResponseWriter, err error) error {
+func RespondError(ctx context.Context, w http.ResponseWriter, err error) error {
 
 	// If the error was of the type *Error, the handler has
 	// a specific status code and error to return.
@@ -46,7 +51,7 @@ func RespondError(w http.ResponseWriter, err error) error {
 			Error:  webErr.Err.Error(),
 			Fields: webErr.Fields,
 		}
-		if err := Respond(w, er, webErr.Status); err != nil {
+		if err := Respond(ctx, w, er, webErr.Status); err != nil {
 			return err
 		}
 		return nil
@@ -56,7 +61,7 @@ func RespondError(w http.ResponseWriter, err error) error {
 	er := ErrorResponse{
 		Error: http.StatusText(http.StatusInternalServerError),
 	}
-	if err := Respond(w, er, http.StatusInternalServerError); err != nil {
+	if err := Respond(ctx, w, er, http.StatusInternalServerError); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
resolves #48                

### Description

This PR adds the Logger middleware. The middleware uses context to log the response code and request date/time.

### How to Test

- [ ] Make various requests and confirm the response code, response type and current date/time are logged
```
> go run ./cmd/api

STATIONS : 2021/01/25 19:17:44.036402 main.go:85: main : Started
STATIONS : 2021/01/25 19:17:44.036587 main.go:92: main : Config :
--web-address=localhost:8000
--web-debug=localhost:6060
--web-read-timeout=5s
--web-write-timeout=5s
--web-shutdown-timeout=5s
--db-user=postgres
--db-host=localhost
--db-name=postgres
--db-disable-tls=true
STATIONS : 2021/01/25 19:17:44.036741 main.go:119: debug service listening on localhost:6060
STATIONS : 2021/01/25 19:17:44.036754 main.go:154: main : API listening on localhost:8000
STATIONS : 2021/01/25 19:17:48.675701 logger.go:30: (200) : GET /v1/station-types -> 127.0.0.1:53660 (34.753308ms)
STATIONS : 2021/01/25 19:18:22.589897 errors.go:26: ERROR : ID is not in its proper UUID format
STATIONS : 2021/01/25 19:18:22.590087 logger.go:30: (400) : GET /v1/station-type/invalid-uuid -> 127.0.0.1:53664 (192.601µs)
STATIONS : 2021/01/25 19:18:35.010095 logger.go:30: (200) : GET /v1/station-type/a2b0639f-2cc6-44b8-b97b-15d69dbb511e -> 127.0.0.1:53667 (4.312935ms)
STATIONS : 2021/01/25 19:18:45.034497 logger.go:30: (201) : POST /v1/station-type -> 127.0.0.1:53670 (6.408225ms)
STATIONS : 2021/01/25 19:19:13.724064 logger.go:30: (204) : DELETE /v1/station/e7456195-2eb5-4741-a7db-38b332c3acaa -> 127.0.0.1:53678 (11.242005ms)
```