### PR TITLE
Issue-50 refactor context

### DIFF
--- a/cmd/api/internal/handlers/check.go
+++ b/cmd/api/internal/handlers/check.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	// Core packages
 	"net/http"
 
@@ -18,22 +19,22 @@ type Check struct {
 }
 
 // Health validates the service is healthy and ready to accept requests.
-func (c *Check) Health(w http.ResponseWriter, r *http.Request) error {
+func (c *Check) Health(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 
 	var health struct {
 		Status string `json:"status"`
 	}
 
 	// Check if the database is ready.
-	if err := database.StatusCheck(r.Context(), c.db); err != nil {
+	if err := database.StatusCheck(ctx, c.db); err != nil {
 
 		// If the database is not ready we will tell the client and use a 500
 		// status. Do not respond by just returning an error because further up in
 		// the call stack will interpret that as an unhandled error.
 		health.Status = "db not ready"
-		return web.Respond(r.Context(), w, health, http.StatusInternalServerError)
+		return web.Respond(ctx, w, health, http.StatusInternalServerError)
 	}
 
 	health.Status = "ok"
-	return web.Respond(r.Context(), w, health, http.StatusOK)
+	return web.Respond(ctx, w, health, http.StatusOK)
 }

--- a/cmd/api/internal/handlers/station_type.go
+++ b/cmd/api/internal/handlers/station_type.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	// Core packages
+	"context"
 	"log"
 	"net/http"
 	"time"
@@ -23,7 +24,7 @@ type StationType struct {
 
 // Create decodes the body of a request to create a new station type. The full
 // station type with generated fields is sent back in the response.
-func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) Create(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 
 	var nst station_type.NewStationType
 
@@ -31,19 +32,19 @@ func (st *StationType) Create(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "decoding new station type")
 	}
 
-	stationType, err := station_type.Create(r.Context(), st.db, nst, time.Now())
+	stationType, err := station_type.Create(ctx, st.db, nst, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "creating new station type")
 	}
 
-	return web.Respond(r.Context(), w, &stationType, http.StatusCreated)
+	return web.Respond(ctx, w, &stationType, http.StatusCreated)
 }
 
 // Delete removes a single station type identified by an ID in the request URL.
-func (p *StationType) Delete(w http.ResponseWriter, r *http.Request) error {
+func (p *StationType) Delete(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	if err := station_type.Delete(r.Context(), p.db, id); err != nil {
+	if err := station_type.Delete(ctx, p.db, id); err != nil {
 		switch err {
 		case station_type.ErrInvalidID:
 			return web.NewRequestError(err, http.StatusBadRequest)
@@ -52,7 +53,7 @@ func (p *StationType) Delete(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
+	return web.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 /**
@@ -65,21 +66,21 @@ func (p *StationType) Delete(w http.ResponseWriter, r *http.Request) error {
  * Note: If you open localhost:8000 in your browser, you may notice double requests being made. This happens because
  * the browser sends a request in the background for a website favicon. More the reason to use Postman to test!
  */
-func (st *StationType) List(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) List(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 
-	list, err := station_type.List(r.Context(), st.db)
+	list, err := station_type.List(ctx, st.db)
 	if err != nil {
 		return errors.Wrap(err, "getting station type list")
 	}
 
-	return web.Respond(r.Context(), w, list, http.StatusOK)
+	return web.Respond(ctx, w, list, http.StatusOK)
 }
 
 // Retrieve finds all stations of a station type identified by a station type ID in the request URL.
-func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) Retrieve(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	stationTypes, err := station_type.Retrieve(r.Context(), st.db, id)
+	stationTypes, err := station_type.Retrieve(ctx, st.db, id)
 	if err != nil {
 		switch err {
 		case station_type.ErrNotFound:
@@ -91,12 +92,12 @@ func (st *StationType) Retrieve(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(r.Context(), w, stationTypes, http.StatusOK)
+	return web.Respond(ctx, w, stationTypes, http.StatusOK)
 }
 
 // Update decodes the body of a request to update an existing station type. The ID
 // of the station type is part of the request URL.
-func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) Update(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
 	var update station_type.UpdateStationType
@@ -104,7 +105,7 @@ func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "decoding station type update")
 	}
 
-	if err := station_type.Update(r.Context(), st.db, id, update, time.Now()); err != nil {
+	if err := station_type.Update(ctx, st.db, id, update, time.Now()); err != nil {
 		switch err {
 		case station_type.ErrNotFound:
 			return web.NewRequestError(err, http.StatusNotFound)
@@ -115,7 +116,7 @@ func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
+	return web.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 /**
@@ -124,7 +125,7 @@ func (st *StationType) Update(w http.ResponseWriter, r *http.Request) error {
 
 // AddStation creates a new Station for a particular station_type. It looks for a JSON
 // object in the request body. The full model is returned to the caller.
-func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) AddStation(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var ns station_type.NewStation
 	if err := web.Decode(r, &ns); err != nil {
 		return errors.Wrap(err, "decoding new station")
@@ -132,19 +133,19 @@ func (st *StationType) AddStation(w http.ResponseWriter, r *http.Request) error 
 
 	stationTypeId := chi.URLParam(r, "id")
 
-	station, err := station_type.AddStation(r.Context(), st.db, ns, stationTypeId, time.Now())
+	station, err := station_type.AddStation(ctx, st.db, ns, stationTypeId, time.Now())
 	if err != nil {
 		return errors.Wrap(err, "adding new sale")
 	}
 
-	return web.Respond(r.Context(), w, station, http.StatusCreated)
+	return web.Respond(ctx, w, station, http.StatusCreated)
 }
 
 // Delete removes a single station identified by an ID in the request URL.
-func (p *StationType) DeleteStation(w http.ResponseWriter, r *http.Request) error {
+func (p *StationType) DeleteStation(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	if err := station_type.DeleteStation(r.Context(), p.db, id); err != nil {
+	if err := station_type.DeleteStation(ctx, p.db, id); err != nil {
 		switch err {
 		case station_type.ErrInvalidID:
 			return web.NewRequestError(err, http.StatusBadRequest)
@@ -153,26 +154,26 @@ func (p *StationType) DeleteStation(w http.ResponseWriter, r *http.Request) erro
 		}
 	}
 
-	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
+	return web.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 // ListStations gets all sales for a particular station type.
-func (st *StationType) ListStations(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) ListStations(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	list, err := station_type.ListStations(r.Context(), st.db, id)
+	list, err := station_type.ListStations(ctx, st.db, id)
 	if err != nil {
 		return errors.Wrap(err, "getting sales list")
 	}
 
-	return web.Respond(r.Context(), w, list, http.StatusOK)
+	return web.Respond(ctx, w, list, http.StatusOK)
 }
 
 // Retrieve finds a single station identified by an ID in the request URL.
-func (st *StationType) RetrieveStation(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) RetrieveStation(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
-	station, err := station_type.RetrieveStation(r.Context(), st.db, id)
+	station, err := station_type.RetrieveStation(ctx, st.db, id)
 	if err != nil {
 		switch err {
 		case station_type.ErrStationNotFound:
@@ -184,12 +185,12 @@ func (st *StationType) RetrieveStation(w http.ResponseWriter, r *http.Request) e
 		}
 	}
 
-	return web.Respond(r.Context(), w, station, http.StatusOK)
+	return web.Respond(ctx, w, station, http.StatusOK)
 }
 
 // Update decodes the body of a request to update an existing station. The ID
 // of the station is part of the request URL.
-func (st *StationType) AdjustStation(w http.ResponseWriter, r *http.Request) error {
+func (st *StationType) AdjustStation(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	id := chi.URLParam(r, "id")
 
 	var update station_type.UpdateStation
@@ -197,7 +198,7 @@ func (st *StationType) AdjustStation(w http.ResponseWriter, r *http.Request) err
 		return errors.Wrap(err, "decoding station update")
 	}
 
-	if err := station_type.AdjustStation(r.Context(), st.db, id, update, time.Now()); err != nil {
+	if err := station_type.AdjustStation(ctx, st.db, id, update, time.Now()); err != nil {
 		switch err {
 		case station_type.ErrStationNotFound:
 			return web.NewRequestError(err, http.StatusNotFound)
@@ -208,5 +209,5 @@ func (st *StationType) AdjustStation(w http.ResponseWriter, r *http.Request) err
 		}
 	}
 
-	return web.Respond(r.Context(), w, nil, http.StatusNoContent)
+	return web.Respond(ctx, w, nil, http.StatusNoContent)
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -45,7 +45,7 @@ func run() error {
 
 	// Use "shadowing" to override the global log package value. See https://golang.org/src/log/log.go#L37 for possible
 	// bit values to manage output
-	log := log.New(os.Stdout, "STATIONS : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+	log := log.New(os.Stdout, "STATIONS API : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
 
 	// =========================================================================
 	// Configuration

--- a/internal/mid/errors.go
+++ b/internal/mid/errors.go
@@ -2,6 +2,7 @@ package mid
 
 import (
 	// Core packages
+	"context"
 	"log"
 	"net/http"
 
@@ -17,16 +18,16 @@ func Errors(log *log.Logger) web.Middleware {
 	// This is the actual middleware function to be executed.
 	f := func(before web.Handler) web.Handler {
 
-		h := func(w http.ResponseWriter, r *http.Request) error {
+		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 
 			// Run the handler chain and catch any propagated error.
-			if err := before(w, r); err != nil {
+			if err := before(ctx, w, r); err != nil {
 
 				// Log the error.
 				log.Printf("ERROR : %+v", err)
 
 				// Respond to the error.
-				if err := web.RespondError(r.Context(), w, err); err != nil {
+				if err := web.RespondError(ctx, w, err); err != nil {
 					return err
 				}
 			}

--- a/internal/mid/logger.go
+++ b/internal/mid/logger.go
@@ -1,6 +1,7 @@
 package mid
 
 import (
+	"context"
 	// Core packages
 	"errors"
 	"log"
@@ -19,13 +20,13 @@ func Logger(log *log.Logger) web.Middleware {
 	f := func(before web.Handler) web.Handler {
 
 		// Create the handler that will be attached in the middleware chain.
-		h := func(w http.ResponseWriter, r *http.Request) error {
-			v, ok := r.Context().Value(web.KeyValues).(*web.Values)
+		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			v, ok := ctx.Value(web.KeyValues).(*web.Values)
 			if !ok {
 				return errors.New("web value missing from context")
 			}
 
-			err := before(w, r)
+			err := before(ctx, w, r)
 
 			// Format log message
 			// ex: POST (201) : /v1/station-type -> 127.0.0.1:53670 (6.408225ms)

--- a/internal/mid/metrics.go
+++ b/internal/mid/metrics.go
@@ -1,7 +1,8 @@
 package mid
 
 import (
-	// COre packages
+	// Core packages
+	"context"
 	"expvar"
 	"net/http"
 	"runtime"
@@ -28,9 +29,9 @@ func Metrics() web.Middleware {
 	f := func(before web.Handler) web.Handler {
 
 		// Wrap this handler around the next one provided.
-		h := func(w http.ResponseWriter, r *http.Request) error {
+		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 
-			err := before(w, r)
+			err := before(ctx, w, r)
 
 			// Increment the request counter.
 			m.req.Add(1)

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -24,7 +24,7 @@ type Values struct {
 }
 
 // Handler is the signature used by all application handlers in this service.
-type Handler func(http.ResponseWriter, *http.Request) error
+type Handler func(context.Context, http.ResponseWriter, *http.Request) error
 
 // App is the entrypoint into our application and what controls the context of
 // each request. Feel free to add any configuration data/logic on this type.
@@ -63,10 +63,9 @@ func (a *App) Handle(method, url string, h Handler) {
 			Start: time.Now(),
 		}
 		ctx := context.WithValue(r.Context(), KeyValues, &v)
-		r = r.WithContext(ctx)
 
 		// Run the handler chain and catch any propagated error.
-		if err := h(w, r); err != nil {
+		if err := h(ctx, w, r); err != nil {
 			a.log.Printf("Unhandled error: %+v", err)
 		}
 	}


### PR DESCRIPTION
resolves #50                

### Description

This PR refactors how `context.Context` is implemented. This refactor is needed to support future auth functionality.

### How to Test

- [ ] confirm tests continue to pass
```
> go test ./cmd/api/tests/station_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_tests	9.416s

> go test ./cmd/api/tests/station_type_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_type_tests	2.427s

> go test ./internal/station_type
ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	8.493s
```