### PR TITLE
Issue-52 Add accounts (users)

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -81,7 +81,7 @@ func run() error {
 		err = migrate(dbConfig)
 	case "seed":
 		err = seed(dbConfig)
-	case "accountadd":
+	case "accountAdd":
 		// name, password
 		err = adminAdd(dbConfig, cfg.Args.Num(1), cfg.Args.Num(2))
 	default:

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -82,7 +82,8 @@ func run() error {
 	case "seed":
 		err = seed(dbConfig)
 	case "accountadd":
-		err = accountadd(dbConfig, cfg.Args.Num(1), cfg.Args.Num(2))
+		// name, password
+		err = adminAdd(dbConfig, cfg.Args.Num(1), cfg.Args.Num(2))
 	default:
 		err = errors.New("Must specify a command")
 	}
@@ -124,7 +125,7 @@ func seed(cfg database.Config) error {
 	return nil
 }
 
-func accountadd(cfg database.Config, email, password string) error {
+func adminAdd(cfg database.Config, name, password string) error {
 	db, err := database.Open(cfg)
 	if err != nil {
 		return err
@@ -132,10 +133,10 @@ func accountadd(cfg database.Config, email, password string) error {
 	defer db.Close()
 
 	if password == "" {
-		return errors.New("accountadd command must be called with additional argument password")
+		return errors.New("adminAdd command must be called with additional argument password")
 	}
 
-	fmt.Printf("Account will be created with password %q\n", password)
+	fmt.Printf("Admin account will be created with password %q\n", password)
 	fmt.Print("Continue? (1/0) ")
 
 	var confirm bool
@@ -151,9 +152,10 @@ func accountadd(cfg database.Config, email, password string) error {
 	ctx := context.Background()
 
 	na := account.NewAccount{
+		Name:            name,
 		Password:        password,
 		PasswordConfirm: password,
-		Roles:           []string{auth.RoleAdmin, auth.RoleAccount},
+		Roles:           []string{auth.RoleAdmin, auth.RoleStation},
 	}
 
 	a, err := account.Create(ctx, db, na, time.Now())

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.6 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -1,0 +1,46 @@
+package account
+
+import (
+	// Core packages
+	"context"
+	"time"
+
+	// Third-party packages
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Create inserts a new account into the database.
+func Create(ctx context.Context, db *sqlx.DB, n NewAccount, now time.Time) (*Account, error) {
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(n.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating password hash")
+	}
+
+	a := Account{
+		Id:           uuid.New().String(),
+		Name:         n.Name,
+		PasswordHash: hash,
+		Roles:        n.Roles,
+		DateCreated:  now.UTC(),
+		DateUpdated:  now.UTC(),
+	}
+
+	const q = `INSERT INTO account
+		(id, name, password_hash, roles, date_created, date_updated)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err = db.ExecContext(
+		ctx, q,
+		a.Id, a.Name,
+		a.PasswordHash, a.Roles,
+		a.DateCreated, a.DateUpdated,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "inserting account")
+	}
+
+	return &a, nil
+}

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -31,7 +31,7 @@ func Create(ctx context.Context, db *sqlx.DB, n NewAccount, now time.Time) (*Acc
 
 	const q = `INSERT INTO account
 		(id, name, password_hash, roles, date_created, date_updated)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)`
+		VALUES ($1, $2, $3, $4, $5, $6)`
 	_, err = db.ExecContext(
 		ctx, q,
 		a.Id, a.Name,

--- a/internal/account/models.go
+++ b/internal/account/models.go
@@ -1,0 +1,25 @@
+package account
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// Account represents a thing with access to the system.
+type Account struct {
+	Id           string         `db:"id" json:"id"`
+	Name         string         `db:"name" json:"name"`
+	Roles        pq.StringArray `db:"roles" json:"roles"`
+	PasswordHash []byte         `db:"password_hash" json:"-"`
+	DateCreated  time.Time      `db:"date_created" json:"date_created"`
+	DateUpdated  time.Time      `db:"date_updated" json:"date_updated"`
+}
+
+// NewAccount contains information needed to create a new Account.
+type NewAccount struct {
+	Name            string   `json:"name" validate:"required"`
+	Roles           []string `json:"roles" validate:"required"`
+	Password        string   `json:"password" validate:"required"`
+	PasswordConfirm string   `json:"password_confirm" validate:"eqfield=Password"`
+}

--- a/internal/platform/auth/roles.go
+++ b/internal/platform/auth/roles.go
@@ -1,0 +1,7 @@
+package auth
+
+// These are the expected values for Claims.Roles.
+const (
+	RoleAdmin = "ADMIN"
+	RoleAccount  = "ACCOUNT"
+)

--- a/internal/platform/auth/roles.go
+++ b/internal/platform/auth/roles.go
@@ -3,5 +3,5 @@ package auth
 // These are the expected values for Claims.Roles.
 const (
 	RoleAdmin = "ADMIN"
-	RoleAccount  = "ACCOUNT"
+	RoleStation  = "STATION"
 )

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -52,7 +52,7 @@ CREATE TABLE station (
 		Script: `
 CREATE TABLE account (
 	id       UUID,
-	name          TEXT,
+	name          TEXT UNIQUE,
 	roles         TEXT[],
 	password_hash TEXT,
 	date_created TIMESTAMP,

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -46,6 +46,20 @@ CREATE TABLE station (
 		ON DELETE CASCADE
 );`,
 	},
+	{
+		Version:     3,
+		Description: "Add accounts",
+		Script: `
+CREATE TABLE account (
+	id       UUID,
+	name          TEXT,
+	roles         TEXT[],
+	password_hash TEXT,
+	date_created TIMESTAMP,
+	date_updated TIMESTAMP,
+	PRIMARY KEY (id)
+);`,
+	},
 }
 
 // Migrate attempts to bring the schema for db up to date with the migrations

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -34,6 +34,12 @@ INSERT INTO station (id, station_type_id, name, description, location_x, locatio
     ('feaa0806-590c-11eb-ae93-0242ac130002', '5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant Station Two', 'Some description of Plant Station Two', 4, 3, '2021-01-01 00:00:04.000001+00', '2021-01-01 00:00:04.000001+00'),
     ('0690d086-590d-11eb-ae93-0242ac130002', '5c86bbaa-4ef8-11eb-ae93-0242ac130002', 'Plant Station Three', 'Some description of Plant Station Three', 5, 3, '2021-01-01 00:00:05.000001+00', '2021-01-01 00:00:05.000001+00')
 	ON CONFLICT DO NOTHING;
+
+-- Create admin and regular Account with password "gophers"
+INSERT INTO account (id, name, roles, password_hash, date_created, date_updated) VALUES
+	('5cf37266-3473-4006-984f-9325122678b7', 'Admin', '{ADMIN,USER}', '$2a$10$1ggfMVZV6Js0ybvJufLRUOWHS5f6KneuP0XwwHpJ8L8ipdry9f2/a', '2021-01-01 00:00:00', '2021-01-01 00:00:00'),
+	('45b5fbd3-755f-4379-8f07-a58d4a30fa2f', 'Station', '{USER}', '$2a$10$9/XASPKBbJKVfCAZKDH.UuhsuALDr5vVm6VrYA9VFR8rccK86C1hW', '2021-01-01 00:00:00', '2019-01-01 00:00:00')
+	ON CONFLICT DO NOTHING;
 `
 
 // Seed runs the set of seed-data queries against db. The queries are ran in a

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -37,8 +37,8 @@ INSERT INTO station (id, station_type_id, name, description, location_x, locatio
 
 -- Create admin and regular Account with password "gophers"
 INSERT INTO account (id, name, roles, password_hash, date_created, date_updated) VALUES
-	('5cf37266-3473-4006-984f-9325122678b7', 'Admin', '{ADMIN,USER}', '$2a$10$1ggfMVZV6Js0ybvJufLRUOWHS5f6KneuP0XwwHpJ8L8ipdry9f2/a', '2021-01-01 00:00:00', '2021-01-01 00:00:00'),
-	('45b5fbd3-755f-4379-8f07-a58d4a30fa2f', 'Station', '{USER}', '$2a$10$9/XASPKBbJKVfCAZKDH.UuhsuALDr5vVm6VrYA9VFR8rccK86C1hW', '2021-01-01 00:00:00', '2019-01-01 00:00:00')
+	('5cf37266-3473-4006-984f-9325122678b7', 'Admin', '{ADMIN,STATION}', '$2a$10$1ggfMVZV6Js0ybvJufLRUOWHS5f6KneuP0XwwHpJ8L8ipdry9f2/a', '2021-01-01 00:00:00', '2021-01-01 00:00:00'),
+	('45b5fbd3-755f-4379-8f07-a58d4a30fa2f', 'Station', '{STATION}', '$2a$10$9/XASPKBbJKVfCAZKDH.UuhsuALDr5vVm6VrYA9VFR8rccK86C1hW', '2021-01-01 00:00:00', '2019-01-01 00:00:00')
 	ON CONFLICT DO NOTHING;
 `
 


### PR DESCRIPTION
resolves #52                 

### Description

This PR adds support for accounts (users) as a first step in adding auth support to the application

### How to Test

- [x] confirm `migrate` creates `account` table
- [x] confirm `seed` creates account rows
- [x] confirm `go run ./cmd/admin accountAdd <name> <password>` creates a new admin account