### PR TITLE
Issue-54 JWT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+private.pem

--- a/cmd/api/internal/handlers/account.go
+++ b/cmd/api/internal/handlers/account.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	// Core packages
+	"context"
+	"net/http"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
+	"github.com/deezone/HydroBytes-BaseStation/internal/account"
+
+	// Third-party packages
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+// Account holds handlers for dealing with an account.
+type Account struct {
+	db            *sqlx.DB
+	authenticator *auth.Authenticator
+}
+
+// Token generates an authentication token for an account. The client must include
+// a name and password for the request using HTTP Basic Auth. The account will
+// be identified by name and authenticated by the password.
+func (a *Account) Token(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	v, ok := ctx.Value(web.KeyValues).(*web.Values)
+	if !ok {
+		return errors.New("web value missing from context")
+	}
+
+	name, pass, ok := r.BasicAuth()
+	if !ok {
+		err := errors.New("must provide name and password in Basic auth")
+		return web.NewRequestError(err, http.StatusUnauthorized)
+	}
+
+	claims, err := account.Authenticate(ctx, a.db, v.Start, name, pass)
+	if err != nil {
+		switch err {
+		case account.ErrAuthenticationFailure:
+			return web.NewRequestError(err, http.StatusUnauthorized)
+		default:
+			return errors.Wrap(err, "authenticating")
+		}
+	}
+
+	var tkn struct {
+		Token string `json:"token"`
+	}
+	tkn.Token, err = a.authenticator.GenerateToken(claims)
+	if err != nil {
+		return errors.Wrap(err, "generating token")
+	}
+
+	return web.Respond(ctx, w, tkn, http.StatusOK)
+}

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -7,6 +7,7 @@ import (
 
 	// Internal packages
 	"github.com/deezone/HydroBytes-BaseStation/internal/mid"
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
 
 	// Third-party packages
@@ -14,7 +15,7 @@ import (
 )
 
 // API constructs an http.Handler with all application routes defined.
-func API(db *sqlx.DB, log *log.Logger) http.Handler {
+func API(db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.Handler {
 
 	// Construct the web.App which holds all routes as well as common Middleware.
 	app := web.NewApp(log, mid.Logger(log), mid.Errors(log), mid.Metrics())
@@ -23,6 +24,12 @@ func API(db *sqlx.DB, log *log.Logger) http.Handler {
 		c := Check{db: db}
 
 		app.Handle(http.MethodGet, "/v1/health", c.Health)
+	}
+
+	{
+		// Register user handlers.
+		a := Account{db: db, authenticator: authenticator}
+		app.Handle(http.MethodGet, "/v1/account/token", a.Token)
 	}
 
 	{

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	// Core packages
 	"context"
-	_ "expvar"          // Register the expvar handlers
+	"crypto/rsa"
+	_ "expvar" // Register the expvar handlers
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof" // Register the pprof handlers
@@ -14,11 +16,13 @@ import (
 	"time"
 
 	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
 	"github.com/deezone/HydroBytes-BaseStation/cmd/api/internal/handlers"
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/conf"
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database"
 
 	// Third-party packages
+	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 )
 
@@ -65,6 +69,11 @@ func run() error {
 			Name       string `conf:"default:postgres"`
 			DisableTLS bool   `conf:"default:false"`
 		}
+		Auth struct {
+			KeyID          string `conf:"default:1"`
+			PrivateKeyFile string `conf:"default:private.pem"`
+			Algorithm      string `conf:"default:RS256"`
+		}
 	}
 
 	if err := conf.Parse(os.Args[1:], "STATIONS", &cfg); err != nil {
@@ -90,6 +99,18 @@ func run() error {
 		return errors.Wrap(err, "generating config for output")
 	}
 	log.Printf("main : Config :\n%v\n", out)
+
+	// =========================================================================
+	// Initialize authentication support
+
+	authenticator, err := createAuth(
+		cfg.Auth.PrivateKeyFile,
+		cfg.Auth.KeyID,
+		cfg.Auth.Algorithm,
+	)
+	if err != nil {
+		return errors.Wrap(err, "constructing authenticator")
+	}
 
 	// =========================================================================
 	// Start Database
@@ -139,7 +160,7 @@ func run() error {
 	 */
 	api := http.Server{
 		Addr:         cfg.Web.Address,
-		Handler:      handlers.API(db, log),
+		Handler:      handlers.API(db, log, authenticator),
 		ReadTimeout:  cfg.Web.ReadTimeout,
 		WriteTimeout: cfg.Web.WriteTimeout,
 	}
@@ -199,4 +220,21 @@ func run() error {
 	}
 
 	return nil
+}
+
+func createAuth(privateKeyFile, keyID, algorithm string) (*auth.Authenticator, error) {
+
+	keyContents, err := ioutil.ReadFile(privateKeyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading auth private key")
+	}
+
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(keyContents)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing auth private key")
+	}
+
+	public := auth.NewSimpleKeyLookupFunc(keyID, key.Public().(*rsa.PublicKey))
+
+	return auth.NewAuthenticator(key, keyID, algorithm, public)
 }

--- a/cmd/api/tests/account_tests/account_test.go
+++ b/cmd/api/tests/account_tests/account_test.go
@@ -1,0 +1,100 @@
+package account_tests
+
+import (
+	// Core packages
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/cmd/api/internal/handlers"
+	"github.com/deezone/HydroBytes-BaseStation/internal/tests"
+)
+
+// TestUsers runs a series of tests to exercise User behavior.
+func TestAccount(t *testing.T) {
+	test := tests.New(t)
+	defer test.Teardown()
+
+	ut := AccountTests{app: handlers.API(test.Db, test.Log, test.Authenticator)}
+
+	t.Run("TokenRequireAuth", ut.TokenRequireAuth)
+	t.Run("TokenDenyUnknown", ut.TokenDenyUnknown)
+	t.Run("TokenDenyBadPassword", ut.TokenDenyBadPassword)
+	t.Run("TokenSuccess", ut.TokenSuccess)
+}
+
+// AccountTests holds methods for each account subtest. This type allows passing
+// dependencies for tests while still providing a convenient syntax when
+// subtests are registered.
+type AccountTests struct {
+	app http.Handler
+}
+
+// TokenRequireAuth ensures that requests with no authentication are denied.
+func (at *AccountTests) TokenRequireAuth(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/account/token", nil)
+	resp := httptest.NewRecorder()
+
+	at.app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("getting: expected status code %v, got %v", http.StatusUnauthorized, resp.Code)
+	}
+}
+
+// TokenDenyUnknown ensures that account with an unrecognized name aren't given a token.
+func (at *AccountTests) TokenDenyUnknown(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/account/token", nil)
+	resp := httptest.NewRecorder()
+
+	req.SetBasicAuth("BadDude", "gophers")
+
+	at.app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("getting: expected status code %v, got %v", http.StatusUnauthorized, resp.Code)
+	}
+}
+
+// TokenDenyBadPassword ensures that a known account with a bad password is not authenticated.
+func (at *AccountTests) TokenDenyBadPassword(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/account/token", nil)
+	resp := httptest.NewRecorder()
+
+	req.SetBasicAuth("Admin", "GOPHERS")
+
+	at.app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("getting: expected status code %v, got %v", http.StatusUnauthorized, resp.Code)
+	}
+}
+
+// TokenSuccess tests that a known account with a good password gets a token.
+func (at *AccountTests) TokenSuccess(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/account/token", nil)
+	resp := httptest.NewRecorder()
+
+	req.SetBasicAuth("Admin", "gophers")
+
+	at.app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("getting: expected status code %v, got %v", http.StatusOK, resp.Code)
+	}
+
+	var got map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding: %s", err)
+	}
+
+	if len(got) != 1 {
+		t.Error("unexpected values in token response")
+	}
+
+	if got["token"] == "" {
+		t.Fatal("token was not in response")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
 	github.com/cznic/zappy v0.0.0-20181122101859-ca47d358d4b1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/divan/expvarmon v0.0.0-20190204123027-8bf297f0fa5d // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/go-chi/chi v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,9 @@ github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc/go.mod h1:Y1SNZ4dRUOKX
 github.com/cznic/zappy v0.0.0-20181122101859-ca47d358d4b1 h1:ytLS5Cgkxq6jObotJ+a13nsejdqzLFPliDf8CQ8OkAA=
 github.com/cznic/zappy v0.0.0-20181122101859-ca47d358d4b1/go.mod h1:Y1SNZ4dRUOKXshKUbwUapqNncRrho4mkjQebgEHZLj8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/divan/expvarmon v0.0.0-20190204123027-8bf297f0fa5d h1:Z6x58W9Sr64Rd8Yupo2T9rgqyw5CT+tBoWQNxQlYQmw=
 github.com/divan/expvarmon v0.0.0-20190204123027-8bf297f0fa5d/go.mod h1:G5wXgMabUN3HS2tAEsHpFz+u1p/e6MD80Pe9wcmfucE=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712 h1:aaQcKT9WumO6JEJcRyTqFVq4XUZiUcKR2/GI31TOcz8=

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -3,7 +3,11 @@ package account
 import (
 	// Core packages
 	"context"
+	"database/sql"
 	"time"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
 
 	// Third-party packages
 	"github.com/google/uuid"
@@ -11,6 +15,45 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
+
+var (
+	// ErrAuthenticationFailure occurs when an account attempts to authenticate but something goes wrong.
+	ErrAuthenticationFailure = errors.New("Authentication failed")
+)
+
+/**
+ * Authenticate finds an account by the name (unique) and verifies the password. On
+ * success it returns a Claims value representing the account. The claims can be
+ * used to generate a token for future authentication.
+ */
+
+func Authenticate(ctx context.Context, db *sqlx.DB, now time.Time, name, password string) (auth.Claims, error) {
+
+	const q = `SELECT * FROM account WHERE name = $1`
+
+	var a Account
+	if err := db.GetContext(ctx, &a, q, name); err != nil {
+
+		// Normally we would return ErrNotFound in this scenario but we do not want
+		// to leak to an unauthenticated user which emails are in the system.
+		if err == sql.ErrNoRows {
+			return auth.Claims{}, ErrAuthenticationFailure
+		}
+
+		return auth.Claims{}, errors.Wrap(err, "selecting single account")
+	}
+
+	// Compare the provided password with the saved hash. Use the bcrypt
+	// comparison function so it is cryptographically secure.
+	if err := bcrypt.CompareHashAndPassword(a.PasswordHash, []byte(password)); err != nil {
+		return auth.Claims{}, ErrAuthenticationFailure
+	}
+
+	// If we are this far the request is valid. Create some claims for the account
+	// and generate the token for the account.
+	claims := auth.NewClaims(a.Id, a.Roles, now, time.Hour)
+	return claims, nil
+}
 
 // Create inserts a new account into the database.
 func Create(ctx context.Context, db *sqlx.DB, n NewAccount, now time.Time) (*Account, error) {

--- a/internal/platform/auth/auth.go
+++ b/internal/platform/auth/auth.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	// Core packages
+	"crypto/rsa"
+	"fmt"
+
+	// Third-party packages
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
+)
+
+// KeyLookupFunc is used to map a JWT key id (kid) to the corresponding public key.
+// It is a requirement for creating an Authenticator.
+//
+// * Private keys should be rotated. During the transition period, tokens
+// signed with the old and new keys can coexist by looking up the correct
+// public key by key id (kid).
+//
+// * Key-id-to-public-key resolution is usually accomplished via a public JWKS
+// endpoint. See https://auth0.com/docs/jwks for more details.
+type KeyLookupFunc func(kid string) (*rsa.PublicKey, error)
+
+// NewSimpleKeyLookupFunc is a simple implementation of KeyFunc that only ever
+// supports one key. This is easy for development but in production should be
+// replaced with a caching layer that calls a JWKS endpoint.
+func NewSimpleKeyLookupFunc(activeKID string, publicKey *rsa.PublicKey) KeyLookupFunc {
+	f := func(kid string) (*rsa.PublicKey, error) {
+		if activeKID != kid {
+			return nil, fmt.Errorf("unrecognized key id %q", kid)
+		}
+		return publicKey, nil
+	}
+
+	return f
+}
+
+// Authenticator is used to authenticate clients. It can generate a token for a
+// set of account claims and recreate the claims by parsing the token.
+type Authenticator struct {
+	privateKey       *rsa.PrivateKey
+	activeKID        string
+	algorithm        string
+	pubKeyLookupFunc KeyLookupFunc
+	parser           *jwt.Parser
+}
+
+// NewAuthenticator creates an *Authenticator for use. It will error if:
+// - The private key is nil.
+// - The public key func is nil.
+// - The key ID is blank.
+// - The specified algorithm is unsupported.
+func NewAuthenticator(privateKey *rsa.PrivateKey, activeKID, algorithm string, publicKeyLookupFunc KeyLookupFunc) (*Authenticator, error) {
+	if privateKey == nil {
+		return nil, errors.New("private key cannot be nil")
+	}
+	if activeKID == "" {
+		return nil, errors.New("active kid cannot be blank")
+	}
+	if jwt.GetSigningMethod(algorithm) == nil {
+		return nil, errors.Errorf("unknown algorithm %v", algorithm)
+	}
+	if publicKeyLookupFunc == nil {
+		return nil, errors.New("public key function cannot be nil")
+	}
+
+	/**
+	 * Create the token parser to use. The algorithm used to sign the JWT must be
+     * validated to avoid a critical vulnerability:
+	 * https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+	 * Must be set to ensure "none" parser is not accepted
+	 */
+	parser := jwt.Parser{
+		ValidMethods: []string{algorithm},
+	}
+
+	a := Authenticator{
+		privateKey:       privateKey,
+		activeKID:        activeKID,
+		algorithm:        algorithm,
+		pubKeyLookupFunc: publicKeyLookupFunc,
+		parser:           &parser,
+	}
+
+	return &a, nil
+}
+
+// GenerateToken generates a signed JWT token string representing the account Claims.
+func (a *Authenticator) GenerateToken(claims Claims) (string, error) {
+	method := jwt.GetSigningMethod(a.algorithm)
+
+	tkn := jwt.NewWithClaims(method, claims)
+	tkn.Header["kid"] = a.activeKID
+
+	jwtstr, err := tkn.SignedString(a.privateKey)
+	if err != nil {
+		return "", errors.Wrap(err, "signing token")
+	}
+
+	return jwtstr, nil
+}

--- a/internal/platform/auth/roles.go
+++ b/internal/platform/auth/roles.go
@@ -1,7 +1,39 @@
 package auth
 
+import (
+	// Core packages
+	"time"
+
+	// Third-party packages
+	jwt "github.com/dgrijalva/jwt-go" // json web tokens "jwt" - https://jwt.io/
+)
+
 // These are the expected values for Claims.Roles.
 const (
 	RoleAdmin = "ADMIN"
 	RoleStation  = "STATION"
 )
+
+// Claims represents the authorization claims transmitted via a JWT.
+type Claims struct {
+	Roles []string `json:"roles"`
+	jwt.StandardClaims
+}
+
+/**
+ * NewClaims constructs a Claims value for the identified account. The Claims
+ * expire within a specified duration of the provided time. Additional fields
+ * of the Claims can be set after calling NewClaims is desired.
+ */
+func NewClaims(subject string, roles []string, now time.Time, expires time.Duration) Claims {
+	c := Claims{
+		Roles: roles,
+		StandardClaims: jwt.StandardClaims{
+			Subject:   subject,                 // account id
+			IssuedAt:  now.Unix(),
+			ExpiresAt: now.Add(expires).Unix(),
+		},
+	}
+
+	return c
+}


### PR DESCRIPTION
resolves #54                 

### Description

This PR adds support for generating JWT (json web tokens) for authorized accounts through an endpoint:
```
GET /v1/account/token
```

### How to Test

- [x] confirm admin functionality to generate `pem` file:
```
go run ./cmd/admin keygen private.pem

> cat private.pem
-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEAvhjKNvjrg7YBA7p+Zv5BiLIO9L02j7quMzo/WKNeJBvNFVME
0fCv3ckU1ITc41+JlsH8zs2NTdRlECNliqfsWdbMx66bt3Mfc/vw84/usFBx1Dpt

...

qcp0yFJI/PhwQgR8HmbqV7dxV8edgI8OYFe3k48MTEyeXsd3OFJIVGeBysG/qDqx
dh+W3hF6l/C4+ylgMvI/2o0+t7/jVyR6Usons/+99+UtXugDPL5hfA==
-----END RSA PRIVATE KEY-----
```

- [x] confirm `pem` file is not under version control via `.gitignore` setting
- [x] confirm request to: `GET /v1/account/token` with valid admin account credentals responds what a jwd token:
```
{
    "token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJ ... KSh8Y7-suabg"
}
```

- [x] validate token includes expected custom values "roles":
![image](https://user-images.githubusercontent.com/2119264/106088274-ab2b6780-60f3-11eb-91c4-f0de9d36de29.png)

- [x] confirm tests are passing
```
> go test ./cmd/api/tests/station_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_tests	7.253s

> go test ./cmd/api/tests/station_type_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_type_tests	3.592s

> go test ./cmd/api/tests/account_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/account_tests	3.584s

> go test ./internal/station_type
ok  	github.com/deezone/HydroBytes-BaseStation/internal/station_type	9.805s
```

**References**:
- https://jwt.io/




