### PR TITLE
Issue-56 Add JWT validatoin

### DIFF
--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -21,8 +21,8 @@ func API(db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.H
 	app := web.NewApp(log, mid.Logger(log), mid.Errors(log), mid.Metrics())
 
 	{
+		// Register health check handler. This route is not authenticated.
 		c := Check{db: db}
-
 		app.Handle(http.MethodGet, "/v1/health", c.Health)
 	}
 
@@ -33,19 +33,20 @@ func API(db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.H
 	}
 
 	{
+		// Register StationType handlers. Ensure all routes are authenticated.
 		st := StationType{db: db, log: log}
 
-		app.Handle(http.MethodGet,    "/v1/station-types",     st.List)
-		app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve)
-		app.Handle(http.MethodPost,   "/v1/station-type",      st.Create)
-		app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update)
-		app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete)
+		app.Handle(http.MethodGet,    "/v1/station-types",     st.List,     mid.Authenticate(authenticator))
+		app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve, mid.Authenticate(authenticator))
+		app.Handle(http.MethodPost,   "/v1/station-type",      st.Create,   mid.Authenticate(authenticator))
+		app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update,   mid.Authenticate(authenticator))
+		app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete,   mid.Authenticate(authenticator))
 
-		app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations)
-		app.Handle(http.MethodGet,    "/v1/station/{id}",               st.RetrieveStation)
-		app.Handle(http.MethodPost,   "/v1/station-type/{id}/station",  st.AddStation)
-		app.Handle(http.MethodPut,    "/v1/station/{id}",               st.AdjustStation)
-		app.Handle(http.MethodDelete, "/v1/station/{id}",               st.DeleteStation)
+		app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations,    mid.Authenticate(authenticator))
+		app.Handle(http.MethodGet,    "/v1/station/{id}",               st.RetrieveStation, mid.Authenticate(authenticator))
+		app.Handle(http.MethodPost,   "/v1/station-type/{id}/station",  st.AddStation,      mid.Authenticate(authenticator))
+		app.Handle(http.MethodPut,    "/v1/station/{id}",               st.AdjustStation,   mid.Authenticate(authenticator))
+		app.Handle(http.MethodDelete, "/v1/station/{id}",               st.DeleteStation,   mid.Authenticate(authenticator))
 	}
 
 	return app

--- a/cmd/api/tests/account_tests/account_test.go
+++ b/cmd/api/tests/account_tests/account_test.go
@@ -17,7 +17,10 @@ func TestAccount(t *testing.T) {
 	test := tests.New(t)
 	defer test.Teardown()
 
-	ut := AccountTests{app: handlers.API(test.Db, test.Log, test.Authenticator)}
+	ut := AccountTests{
+		app:        handlers.API(test.Db, test.Log, test.Authenticator),
+		adminToken: test.Token("Admin", "gophers"),
+	}
 
 	t.Run("TokenRequireAuth", ut.TokenRequireAuth)
 	t.Run("TokenDenyUnknown", ut.TokenDenyUnknown)
@@ -30,6 +33,7 @@ func TestAccount(t *testing.T) {
 // subtests are registered.
 type AccountTests struct {
 	app http.Handler
+	adminToken string
 }
 
 // TokenRequireAuth ensures that requests with no authentication are denied.

--- a/cmd/api/tests/station_tests/station_test.go
+++ b/cmd/api/tests/station_tests/station_test.go
@@ -29,7 +29,10 @@ func TestStation(t *testing.T) {
 	test := tests.New(t)
 	defer test.Teardown()
 
-	productTests := StationTests{app: handlers.API(test.Db, test.Log, test.Authenticator)}
+	productTests := StationTests{
+		app:        handlers.API(test.Db, test.Log, test.Authenticator),
+		adminToken: test.Token("Admin", "gophers"),
+	}
 
 	t.Run("ListStations", productTests.ListStations)
 	t.Run("CreateRequiresFields", productTests.CreateRequiresFields)
@@ -41,6 +44,7 @@ func TestStation(t *testing.T) {
 // when subtests are registered.
 type StationTests struct {
 	app http.Handler
+	adminToken string
 }
 
 func (st *StationTests) ListStations(t *testing.T) {
@@ -48,6 +52,8 @@ func (st *StationTests) ListStations(t *testing.T) {
 	// Get list of stations by the Plant StationType (5c86bbaa-4ef8-11eb-ae93-0242ac130002) as defined in the seed data
 	req := httptest.NewRequest("GET", "/v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/stations", nil)
 	resp := httptest.NewRecorder()
+
+	req.Header.Set("Authorization", "Bearer " + st.adminToken)
 
 	st.app.ServeHTTP(resp, req)
 
@@ -101,7 +107,9 @@ func (st *StationTests) ListStations(t *testing.T) {
 func (st *StationTests) CreateRequiresFields(t *testing.T) {
 	body := strings.NewReader(`{}`)
 	req := httptest.NewRequest("POST", "/v1/station-type/5c86bbaa-4ef8-11eb-ae93-0242ac130002/station", body)
+
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer " + st.adminToken)
 
 	resp := httptest.NewRecorder()
 
@@ -121,6 +129,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		// Create new station of type Water StationType (72f8b983-3eb4-48db-9ed0-e45cc6bd716b) as defined in the seed data
 		req := httptest.NewRequest("POST", "/v1/station-type/72f8b983-3eb4-48db-9ed0-e45cc6bd716b/station", body)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -163,6 +172,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		url := fmt.Sprintf("/v1/station/%s", actual["id"])
 		req := httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -187,6 +197,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		url := fmt.Sprintf("/v1/station/%s", actual["id"])
 		req := httptest.NewRequest("PUT", url, body)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -198,6 +209,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		// Retrieve updated record to be sure it worked.
 		req = httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp = httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -231,6 +243,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 	{ // DELETE
 		url := fmt.Sprintf("/v1/station/%s", actual["id"])
 		req := httptest.NewRequest("DELETE", url, nil)
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -242,6 +255,7 @@ func (st *StationTests) StationCRUD(t *testing.T) {
 		// Retrieve updated record to be sure it worked.
 		req = httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp = httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)

--- a/cmd/api/tests/station_type_tests/station_type_test.go
+++ b/cmd/api/tests/station_type_tests/station_type_test.go
@@ -29,7 +29,10 @@ func TestStationType(t *testing.T) {
 	test := tests.New(t)
 	defer test.Teardown()
 
-	stationTypeTests := StationTypeTests{app: handlers.API(test.Db, test.Log, test.Authenticator)}
+	stationTypeTests := StationTypeTests{
+		app:        handlers.API(test.Db, test.Log, test.Authenticator),
+		adminToken: test.Token("Admin", "gophers"),
+	}
 
 	t.Run("List", stationTypeTests.List)
 	t.Run("CreateRequiresFields", stationTypeTests.CreateRequiresFields)
@@ -41,11 +44,14 @@ func TestStationType(t *testing.T) {
 // when subtests are registered.
 type StationTypeTests struct {
 	app http.Handler
+	adminToken string
 }
 
 func (st *StationTypeTests) List(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/station-types", nil)
 	resp := httptest.NewRecorder()
+
+	req.Header.Set("Authorization", "Bearer " + st.adminToken)
 
 	st.app.ServeHTTP(resp, req)
 
@@ -90,14 +96,16 @@ func (st *StationTypeTests) List(t *testing.T) {
 	}
 }
 
-func (p *StationTypeTests) CreateRequiresFields(t *testing.T) {
+func (st *StationTypeTests) CreateRequiresFields(t *testing.T) {
 	body := strings.NewReader(`{}`)
 	req := httptest.NewRequest("POST", "/v1/station-type", body)
+
+	req.Header.Set("Authorization", "Bearer " + st.adminToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp := httptest.NewRecorder()
 
-	p.app.ServeHTTP(resp, req)
+	st.app.ServeHTTP(resp, req)
 
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("getting: expected status code %v, got %v", http.StatusBadRequest, resp.Code)
@@ -111,6 +119,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 		body := strings.NewReader(`{"name":"stationtype0","description":"Test description 0"}`)
 
 		req := httptest.NewRequest("POST", "/v1/station-type", body)
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
@@ -152,6 +161,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
 		req := httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -176,6 +186,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
 		req := httptest.NewRequest("PUT", url, body)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -187,6 +198,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 		// Retrieve updated record to be sure it worked.
 		req = httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp = httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -218,6 +230,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 	{ // DELETE
 		url := fmt.Sprintf("/v1/station-type/%s", actual["id"])
 		req := httptest.NewRequest("DELETE", url, nil)
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp := httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)
@@ -229,6 +242,7 @@ func (st *StationTypeTests) StationTypeCRUD(t *testing.T) {
 		// Retrieve updated record to be sure it worked.
 		req = httptest.NewRequest("GET", url, nil)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer " + st.adminToken)
 		resp = httptest.NewRecorder()
 
 		st.app.ServeHTTP(resp, req)

--- a/internal/mid/auth.go
+++ b/internal/mid/auth.go
@@ -1,0 +1,48 @@
+package mid
+
+import (
+	// Core packages
+	"context"
+	"net/http"
+	"strings"
+
+	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
+
+	// Third-party packages
+	"github.com/pkg/errors"
+)
+
+// Authenticate validates a JWT from the `Authorization` header.
+func Authenticate(authenticator *auth.Authenticator) web.Middleware {
+
+	// This is the actual middleware function to be executed.
+	f := func(after web.Handler) web.Handler {
+
+		// Wrap this handler around the next one provided.
+		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			// Parse the authorization header. Expected header is of
+			// the format `Bearer <token>`.
+			parts := strings.Split(r.Header.Get("Authorization"), " ")
+			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+				err := errors.New("expected authorization header format: Bearer <token>")
+				return web.NewRequestError(err, http.StatusUnauthorized)
+			}
+
+			claims, err := authenticator.ParseClaims(parts[1])
+			if err != nil {
+				return web.NewRequestError(err, http.StatusUnauthorized)
+			}
+
+			// Add claims to the context so they can be retrieved later.
+			ctx = context.WithValue(ctx, auth.Key, claims)
+
+			return after(ctx, w, r)
+		}
+
+		return h
+	}
+
+	return f
+}

--- a/internal/platform/auth/roles.go
+++ b/internal/platform/auth/roles.go
@@ -14,22 +14,26 @@ const (
 	RoleStation  = "STATION"
 )
 
+// ctxKey represents the type of value for the context key.
+type ctxKey int
+
+// Key is used to store/retrieve a Claims value from a context.Context.
+const Key ctxKey = 1
+
 // Claims represents the authorization claims transmitted via a JWT.
 type Claims struct {
 	Roles []string `json:"roles"`
 	jwt.StandardClaims
 }
 
-/**
- * NewClaims constructs a Claims value for the identified account. The Claims
- * expire within a specified duration of the provided time. Additional fields
- * of the Claims can be set after calling NewClaims is desired.
- */
+// NewClaims constructs a Claims value for the identified user. The Claims
+// expire within a specified duration of the provided time. Additional fields
+// of the Claims can be set after calling NewClaims is desired.
 func NewClaims(subject string, roles []string, now time.Time, expires time.Duration) Claims {
 	c := Claims{
 		Roles: roles,
 		StandardClaims: jwt.StandardClaims{
-			Subject:   subject,                 // account id
+			Subject:   subject, // account id
 			IssuedAt:  now.Unix(),
 			ExpiresAt: now.Add(expires).Unix(),
 		},

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -48,9 +48,12 @@ func NewApp(log *log.Logger, mw ...Middleware) *App {
 //
 // It converts our custom handler type to the std lib Handler type. It captures
 // errors from the handler and serves them to the client in a uniform way.
-func (a *App) Handle(method, url string, h Handler) {
+func (a *App) Handle(method, url string, h Handler, mw ...Middleware) {
 
-	// wrap the application's middleware around this endpoint's handler.
+	// First wrap handler specific middleware around this handler.
+	h = wrapMiddleware(mw, h)
+
+	// Add the application's general middleware to the handler chain.
 	h = wrapMiddleware(a.mw, h)
 
 	// Create a function that conforms to the std lib definition of a handler.

--- a/internal/tests/test.go
+++ b/internal/tests/test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
 	"log"
 	"os"
 
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	// Internal packages
+	"github.com/deezone/HydroBytes-BaseStation/internal/platform/auth"
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database"
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/database/databasetest"
 	"github.com/deezone/HydroBytes-BaseStation/internal/schema"
+	"github.com/deezone/HydroBytes-BaseStation/internal/account"
 
 	// Third-party packages
 	"github.com/jmoiron/sqlx"
@@ -130,6 +132,26 @@ func New(t *testing.T) *Test {
 // Teardown releases any resources used for the test.
 func (test *Test) Teardown() {
 	test.cleanup()
+}
+
+// Token generates an authenticated token for a account.
+func (test *Test) Token(name, pass string) string {
+	test.t.Helper()
+
+	claims, err := account.Authenticate(
+		context.Background(), test.Db, time.Now(),
+		name, pass,
+	)
+	if err != nil {
+		test.t.Fatal(err)
+	}
+
+	tkn, err := test.Authenticator.GenerateToken(claims)
+	if err != nil {
+		test.t.Fatal(err)
+	}
+
+	return tkn
 }
 
 // StringPointer is a helper to get a *string from a string. It is in the tests


### PR DESCRIPTION
resolves #54                 

### Description

This PR adds JWT requirement to certain endpoints. 

### How to Test

- [ ] confirm access to certain endpoints that require a valid token work
- [ ] confirm a missing or invalid token to controlled endpoints restricts access - `401`
```
{
    "error": "expected authorization header format: Bearer <token>"
}
```

- [ ] confirm all tests pass
```
> go test ./cmd/api/tests/station_type_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_type_tests	3.579s

> go test ./cmd/api/tests/station_type_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_type_tests	3.268s

> go test ./cmd/api/tests/station_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/station_tests	3.262s

> go test ./cmd/api/tests/account_tests
ok  	github.com/deezone/HydroBytes-BaseStation/cmd/api/tests/account_tests	3.329s
```

Note:
- added script to Postman `GET /v1/account/token` to add token to other request headers in collection:
```
var jsonData = JSON.parse(responseBody);
postman.setEnvironmentVariable("Token", jsonData.token);
```
