### PR TITLE
Issue-59 Add route level authorization by role

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -100,7 +100,7 @@ func run() error {
 	return nil
 }
 
-// adminUser creates an admin user
+// adminAccount creates an admin account
 func adminAdd(cfg database.Config, name, password string) error {
 	db, err := database.Open(cfg)
 	if err != nil {

--- a/cmd/api/internal/handlers/routes.go
+++ b/cmd/api/internal/handlers/routes.go
@@ -27,7 +27,7 @@ func API(db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.H
 	}
 
 	{
-		// Register user handlers.
+		// Register account handlers.
 		a := Account{db: db, authenticator: authenticator}
 		app.Handle(http.MethodGet, "/v1/account/token", a.Token)
 	}
@@ -36,17 +36,37 @@ func API(db *sqlx.DB, log *log.Logger, authenticator *auth.Authenticator) http.H
 		// Register StationType handlers. Ensure all routes are authenticated.
 		st := StationType{db: db, log: log}
 
+		// StationType
 		app.Handle(http.MethodGet,    "/v1/station-types",     st.List,     mid.Authenticate(authenticator))
 		app.Handle(http.MethodGet,    "/v1/station-type/{id}", st.Retrieve, mid.Authenticate(authenticator))
-		app.Handle(http.MethodPost,   "/v1/station-type",      st.Create,   mid.Authenticate(authenticator))
-		app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update,   mid.Authenticate(authenticator))
-		app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete,   mid.Authenticate(authenticator))
+		app.Handle(http.MethodPost,   "/v1/station-type",      st.Create,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
+		app.Handle(http.MethodPut,    "/v1/station-type/{id}", st.Update,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
+		app.Handle(http.MethodDelete, "/v1/station-type/{id}", st.Delete,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
 
+		// Station
 		app.Handle(http.MethodGet,    "/v1/station-type/{id}/stations", st.ListStations,    mid.Authenticate(authenticator))
 		app.Handle(http.MethodGet,    "/v1/station/{id}",               st.RetrieveStation, mid.Authenticate(authenticator))
-		app.Handle(http.MethodPost,   "/v1/station-type/{id}/station",  st.AddStation,      mid.Authenticate(authenticator))
-		app.Handle(http.MethodPut,    "/v1/station/{id}",               st.AdjustStation,   mid.Authenticate(authenticator))
-		app.Handle(http.MethodDelete, "/v1/station/{id}",               st.DeleteStation,   mid.Authenticate(authenticator))
+		app.Handle(http.MethodPost,   "/v1/station-type/{id}/station",  st.AddStation,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
+		app.Handle(http.MethodPut,    "/v1/station/{id}",               st.AdjustStation,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
+		app.Handle(http.MethodDelete, "/v1/station/{id}",               st.DeleteStation,
+			mid.Authenticate(authenticator),
+			mid.HasRole(auth.RoleAdmin),
+		)
 	}
 
 	return app

--- a/cmd/api/tests/account_tests/account_test.go
+++ b/cmd/api/tests/account_tests/account_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/deezone/HydroBytes-BaseStation/internal/tests"
 )
 
-// TestUsers runs a series of tests to exercise User behavior.
+// TestAccount runs a series of tests to exercise Account behavior.
 func TestAccount(t *testing.T) {
 	test := tests.New(t)
 	defer test.Teardown()

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -35,7 +35,7 @@ func Authenticate(ctx context.Context, db *sqlx.DB, now time.Time, name, passwor
 	if err := db.GetContext(ctx, &a, q, name); err != nil {
 
 		// Normally we would return ErrNotFound in this scenario but we do not want
-		// to leak to an unauthenticated user which emails are in the system.
+		// to leak to an unauthenticated account which emails are in the system.
 		if err == sql.ErrNoRows {
 			return auth.Claims{}, ErrAuthenticationFailure
 		}

--- a/internal/platform/auth/auth.go
+++ b/internal/platform/auth/auth.go
@@ -36,7 +36,7 @@ func NewSimpleKeyLookupFunc(activeKID string, publicKey *rsa.PublicKey) KeyLooku
 }
 
 // Authenticator is used to authenticate clients. It can generate a token for a
-// set of user claims and recreate the claims by parsing the token.
+// set of account claims and recreate the claims by parsing the token.
 type Authenticator struct {
 	privateKey       *rsa.PrivateKey
 	activeKID        string
@@ -82,7 +82,7 @@ func NewAuthenticator(privateKey *rsa.PrivateKey, activeKID, algorithm string, p
 	return &a, nil
 }
 
-// GenerateToken generates a signed JWT token string representing the user Claims.
+// GenerateToken generates a signed JWT token string representing the account Claims.
 func (a *Authenticator) GenerateToken(claims Claims) (string, error) {
 	method := jwt.GetSigningMethod(a.algorithm)
 
@@ -109,12 +109,12 @@ func (a *Authenticator) ParseClaims(tokenStr string) (Claims, error) {
 		if !ok {
 			return nil, errors.New("missing key id (kid) in token header")
 		}
-		userKID, ok := kid.(string)
+		accountKID, ok := kid.(string)
 		if !ok {
-			return nil, errors.New("user token key id (kid) must be string")
+			return nil, errors.New("account token key id (kid) must be string")
 		}
 
-		return a.pubKeyLookupFunc(userKID)
+		return a.pubKeyLookupFunc(accountKID)
 	}
 
 	var claims Claims

--- a/internal/platform/auth/roles.go
+++ b/internal/platform/auth/roles.go
@@ -26,7 +26,7 @@ type Claims struct {
 	jwt.StandardClaims
 }
 
-// NewClaims constructs a Claims value for the identified user. The Claims
+// NewClaims constructs a Claims value for the identified account. The Claims
 // expire within a specified duration of the provided time. Additional fields
 // of the Claims can be set after calling NewClaims is desired.
 func NewClaims(subject string, roles []string, now time.Time, expires time.Duration) Claims {
@@ -40,4 +40,16 @@ func NewClaims(subject string, roles []string, now time.Time, expires time.Durat
 	}
 
 	return c
+}
+
+// HasRole returns true if the claims has at least one of the provided roles.
+func (c Claims) HasRole(roles ...string) bool {
+	for _, has := range c.Roles {
+		for _, want := range roles {
+			if has == want {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
resolves #59                  

### Description

This PR adds route level authorization to specific routes for the `admin` role.

### How to Test

- [x] authorize account with general `Station` account and attempt to access a route that is restricted to an `Admin` account. The response should be:
```
{
    "error": "you are not authorized for that action"
}
```

- [x] confirm that an `Admin` account can access the route

