### PR TITLE
Issue-65 distributed tracing

### DIFF
--- a/internal/mid/errors.go
+++ b/internal/mid/errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/deezone/HydroBytes-BaseStation/internal/platform/web"
 
 	// Third-party packages
+	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
 
@@ -26,11 +27,16 @@ func Errors(log *log.Logger) web.Middleware {
 			ctx, span := trace.StartSpan(ctx, "internal.mid.Errors")
 			defer span.End()
 
+			v, ok := ctx.Value(web.KeyValues).(*web.Values)
+			if !ok {
+				return errors.New("web value missing from context")
+			}
+
 			// Run the handler chain and catch any propagated error.
 			if err := before(ctx, w, r); err != nil {
 
 				// Log the error.
-				log.Printf("ERROR : %+v", err)
+				log.Printf("%s : ERROR : %+v", v.TraceID, err)
 
 				// Respond to the error.
 				if err := web.RespondError(ctx, w, err); err != nil {

--- a/internal/mid/logger.go
+++ b/internal/mid/logger.go
@@ -37,7 +37,8 @@ func Logger(log *log.Logger) web.Middleware {
 
 			// Format log message
 			// ex: POST (201) : /v1/station-type -> 127.0.0.1:53670 (6.408225ms)
-			log.Printf("%s (%d) : %s -> %s (%s)",
+			log.Printf("%s : %s (%d) : %s -> %s (%s)",
+				v.TraceID,
 				r.Method, v.StatusCode,
 				r.URL.Path,
 				r.RemoteAddr, time.Since(v.Start),

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -9,6 +9,8 @@ import (
 
 	// Third-party packages
 	"github.com/go-chi/chi"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.opencensus.io/trace"
 )
 
@@ -20,6 +22,7 @@ const KeyValues ctxKey = 1
 
 // Values carries information about each request.
 type Values struct {
+	TraceID    string
 	StatusCode int
 	Start      time.Time
 }
@@ -33,16 +36,32 @@ type App struct {
 	log *log.Logger
 	mux *chi.Mux
 	mw  []Middleware
+	och *ochttp.Handler
 }
 
 // NewApp constructs an App to handle a set of routes. Any Middleware provided
 // will be ran for every request.
 func NewApp(log *log.Logger, mw ...Middleware) *App {
-	return &App{
+
+	app := App{
 		log: log,
 		mux: chi.NewRouter(),
 		mw:  mw,
 	}
+
+	/** Create an OpenCensus HTTP Handler which wraps the router. This will start
+	 * the initial span and annotate it with information about the request/response.
+	 *
+	 * This is configured to use the W3C TraceContext standard to set the remote
+	 * parent if an client request includes the appropriate headers.
+	 * https://w3c.github.io/trace-context/
+	 */
+	app.och = &ochttp.Handler{
+		Handler:     app.mux,
+		Propagation: &tracecontext.HTTPFormat{},
+	}
+
+	return &app
 }
 
 // Handle associates a handler function with an HTTP Method and URL pattern.
@@ -67,13 +86,14 @@ func (a *App) Handle(method, url string, h Handler, mw ...Middleware) {
 		// Create a Values struct to record state for the request. Store the
 		// address in the request's context so it is sent down the call chain.
 		v := Values{
+			TraceID: span.SpanContext().TraceID.String(),
 			Start: time.Now(),
 		}
 		ctx = context.WithValue(ctx, KeyValues, &v)
 
 		// Run the handler chain and catch any propagated error.
 		if err := h(ctx, w, r); err != nil {
-			a.log.Printf("Unhandled error: %+v", err)
+			a.log.Printf("%s : Unhandled error: %+v", v.TraceID, err)
 		}
 	}
 
@@ -82,5 +102,5 @@ func (a *App) Handle(method, url string, h Handler, mw ...Middleware) {
 
 // ServeHTTP implements the http.Handler interface.
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	a.mux.ServeHTTP(w, r)
+	a.och.ServeHTTP(w, r)
 }


### PR DESCRIPTION
resolves #65                    

### Description

This PR enhance the logging message to include a tracing ID. The ID can be used to log spans across applications in a request life cycle.

### How to Test

- [x] review log message generated from requests to include trace id:
```
STATIONS API : 2021/01/31 18:25:05.028603 logger.go:40: 9d27af604d5bb6f14dabfd2f367acc1b : GET (200) : /v1/account/token -> 127.0.0.1:50157 (152.180002ms)
STATIONS API : 2021/01/31 18:25:09.732813 logger.go:40: e81f87a657bf73ecbdca9b3ec9742316 : GET (200) : /v1/station-types -> 127.0.0.1:50157 (12.494057ms)
```

- [x] review zipkin reports to include additional meta data
![image](https://user-images.githubusercontent.com/2119264/106402147-36f40b00-63f6-11eb-9131-821ee506fbf5.png)

![image](https://user-images.githubusercontent.com/2119264/106402197-6c005d80-63f6-11eb-9f47-b490db597c77.png)
